### PR TITLE
Add image with NeptuneUI

### DIFF
--- a/recipes-core/images/core-image-pelux-qt.bb
+++ b/recipes-core/images/core-image-pelux-qt.bb
@@ -1,0 +1,11 @@
+#
+#   Copyright (C) 2017 Pelagicore AB
+#
+
+DESCRIPTION = "Image for creating a Pelux image with Qt frontend"
+
+require recipes-core/images/core-image-pelux.bb
+
+# Pelux components
+IMAGE_INSTALL += " neptune-ui        \
+                 "

--- a/recipes-core/images/core-image-pelux.bb
+++ b/recipes-core/images/core-image-pelux.bb
@@ -3,7 +3,7 @@
 #
 DESCRIPTION = "Image for creating a Pelux image"
 
-require recipes-core/images/core-image-bistro.bb
+require recipes-core/images/core-image-bistro-dev.bb
 
 # Pelux components
 IMAGE_INSTALL += "softwarecontainer"

--- a/recipes-qt/automotive/neptune-ui/neptune.service
+++ b/recipes-qt/automotive/neptune-ui/neptune.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Neptune
+After=dbus.service dbus-session.service systemd-user-sessions.service
+
+[Service]
+ExecStart=/usr/bin/appman -r -c /opt/am/config.yaml -c am-config.yaml --dbus session Main.qml -platform eglfs
+Restart=on-failure
+WorkingDirectory=/opt/neptune
+Environment=QT_IM_MODULE=qtvirtualkeyboard
+Environment=XDG_RUNTIME_DIR=/tmp
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-qt/automotive/neptune-ui_git.bbappend
+++ b/recipes-qt/automotive/neptune-ui_git.bbappend
@@ -2,6 +2,8 @@
 # Copyright Pelagicore 2017
 #
 
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
 RDEPENDS_${PN}_append = "\
       qtquickcontrols    \
       qtgraphicaleffects \

--- a/recipes-qt/automotive/neptune-ui_git.bbappend
+++ b/recipes-qt/automotive/neptune-ui_git.bbappend
@@ -1,0 +1,8 @@
+#
+# Copyright Pelagicore 2017
+#
+
+RDEPENDS_${PN}_append = "\
+      qtquickcontrols    \
+      qtgraphicaleffects \
+      "


### PR DESCRIPTION
Adds an image that includes NeptuneUI. In order to keep a qt free version of the Pelux reference this is done as a new image.