### PR TITLE
Neptune-ui: remove RDEPENDS

### DIFF
--- a/recipes-qt/automotive/neptune-ui_git.bbappend
+++ b/recipes-qt/automotive/neptune-ui_git.bbappend
@@ -4,7 +4,3 @@
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-RDEPENDS_${PN}_append = "\
-      qtquickcontrols    \
-      qtgraphicaleffects \
-      "


### PR DESCRIPTION
The change has been merged to mainline meta-boot2qt

Signed-off-by: Gordan Markuš <gordan.markus@pelagicore.com>