### PR TITLE
neptune-ui: remove default appman config.yaml

### DIFF
--- a/recipes-qt/automotive/neptune-ui/neptune.service
+++ b/recipes-qt/automotive/neptune-ui/neptune.service
@@ -4,7 +4,7 @@ After=dbus-session@root.service
 Requires=dbus-session@root.service
 
 [Service]
-ExecStart=/usr/bin/appman -r -c /opt/am/config.yaml -c /opt/am/sc-config.yaml -c am-config.yaml --dbus session Main.qml -platform eglfs
+ExecStart=/usr/bin/appman -r -c /opt/am/sc-config.yaml -c am-config.yaml --dbus session Main.qml -platform eglfs
 Restart=on-failure
 WorkingDirectory=/opt/neptune
 Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/root/dbus/user_bus_socket


### PR DESCRIPTION
Due to changes in neptune-ui the default QtApplicationManager
config.yaml is not needed to launch the service anymore.

Signed-off-by: Gordan Markuš <gordan.markus@pelagicore.com>