### PR TITLE
neptune-ui: update neptune.service to work with updated meta-boot2qt

### DIFF
--- a/recipes-qt/automotive/neptune-ui/neptune.service
+++ b/recipes-qt/automotive/neptune-ui/neptune.service
@@ -4,9 +4,10 @@ After=dbus-session@root.service
 Requires=dbus-session@root.service
 
 [Service]
-ExecStart=/usr/bin/appman -r -c /opt/am/config.yaml -c /opt/am/sc-config.yaml -c am-config.yaml --dbus session Main.qml -platform eglfs
+ExecStart=/usr/bin/appman -r -c /opt/am/sc-config.yaml -c am-config.yaml --dbus session Main.qml -platform eglfs
 Restart=on-failure
 WorkingDirectory=/opt/neptune
+Environment=LC_ALL=en_US
 Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/root/dbus/user_bus_socket
 Environment=QT_IM_MODULE=qtvirtualkeyboard
 Environment=XDG_RUNTIME_DIR=/tmp


### PR DESCRIPTION
Updates the systemd service for neptune so that it works on Pelux after it has been bumped to morty, https://github.com/Pelagicore/pelux-manifests/pull/35.

- Neptunes am-config.yaml is not depending on AppMans config.yaml anymore.
- Set a UTF-8 locale since AppMan will otherwise fail to find one since it doesn't have UTF-8 in its name.