### PR TITLE
Neptune fixes

### DIFF
--- a/recipes-qt/automotive/neptune-ui/neptune.service
+++ b/recipes-qt/automotive/neptune-ui/neptune.service
@@ -7,6 +7,7 @@ Requires=dbus-session@root.service
 ExecStart=/usr/bin/appman -r -c /opt/am/sc-config.yaml -c am-config.yaml --dbus session Main.qml -platform eglfs
 Restart=on-failure
 WorkingDirectory=/opt/neptune
+Environment=HOME=/home/%u/
 Environment=LC_ALL=en_US
 Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/root/dbus/user_bus_socket
 Environment=QT_IM_MODULE=qtvirtualkeyboard

--- a/recipes-qt/automotive/neptune-ui_git.bbappend
+++ b/recipes-qt/automotive/neptune-ui_git.bbappend
@@ -6,4 +6,5 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 RDEPENDS_${PN}_append = "\
       dbus-session       \
+      qtwebengine        \
       "

--- a/recipes-qt/automotive/neptune-ui_git.bbappend
+++ b/recipes-qt/automotive/neptune-ui_git.bbappend
@@ -7,4 +7,5 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 RDEPENDS_${PN}_append = "\
       dbus-session       \
       qtwebengine        \
+      qtquickcontrols2   \
       "


### PR DESCRIPTION
HOME is needed for qtivi's media-simulator backend
qtwebengine is needed for the browser app
qtquickcontrols2 is used by i18n-demo app