### PR TITLE
core-image-pelux: add GENIVI components

### DIFF
--- a/recipes-core/images/core-image-pelux.bb
+++ b/recipes-core/images/core-image-pelux.bb
@@ -12,4 +12,4 @@ IMAGE_INSTALL += "softwarecontainer"
 # GENIVI components
 IMAGE_INSTALL += " dlt-daemon         \
                    dlt-daemon-systemd \
-                   "
+                 "

--- a/recipes-core/images/core-image-pelux.bb
+++ b/recipes-core/images/core-image-pelux.bb
@@ -1,9 +1,15 @@
 #
-#   Copyright (C) 2016 Pelagicore AB
+#   Copyright (C) 2017 Pelagicore AB
 #
+
 DESCRIPTION = "Image for creating a Pelux image"
 
 require recipes-core/images/core-image-bistro-dev.bb
 
 # Pelux components
 IMAGE_INSTALL += "softwarecontainer"
+
+# GENIVI components
+IMAGE_INSTALL += " dlt-daemon         \
+                   dlt-daemon-systemd \
+                   "


### PR DESCRIPTION
The following GENIVI components are added:
 * dlt-daemon
 * node-state-manager
 * persistence-client-library

Signed-off-by: Gordan Markuš <gordan.markus@pelagicore.com>