### PR TITLE
core-image-pelux: add node-state-manager

### DIFF
--- a/recipes-core/images/core-image-pelux.bb
+++ b/recipes-core/images/core-image-pelux.bb
@@ -12,4 +12,5 @@ IMAGE_INSTALL += "softwarecontainer"
 # GENIVI components
 IMAGE_INSTALL += " dlt-daemon         \
                    dlt-daemon-systemd \
+                   node-state-manager \
                  "


### PR DESCRIPTION
Signed-off-by: Gordan Markuš <gordan.markus@pelagicore.com>