### PR TITLE
base-files: use default fstab

### DIFF
--- a/recipes-core/base-files/base-files/fstab
+++ b/recipes-core/base-files/base-files/fstab
@@ -1,0 +1,1 @@
+/dev/root            /                    auto       defaults              1  1

--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -1,0 +1,7 @@
+#
+#   Copyright (C) 2017 Pelagicore AB
+#
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+SRC_URI += "file://fstab"
+


### PR DESCRIPTION
By default mount /dev/root as a read/write partition.

Singed-off-by: Gordan Markuš <gordan.markus@pelagicore.com>