### PR TITLE
pelux distro: core-image-pelux: inherit poky image

### DIFF
--- a/conf/distro/pelux.conf
+++ b/conf/distro/pelux.conf
@@ -1,0 +1,39 @@
+#
+#   Copyright (C) 2017 Pelagicore AB
+#
+
+require conf/distro/poky.conf
+
+MAINTAINER = "Gordan Markuš <gordan.markus@pelagicore.com>"
+
+# Add distro features
+DISTRO_FEATURES_append = " \
+                          alsa         \
+                          argp         \
+                          bluetooth    \
+                          bluez5       \
+                          ext2         \
+                          irda         \
+                          largefile    \
+                          opengl       \
+                          pcmcia       \
+                          usbgadget    \
+                          usbhost      \
+                          wifi         \
+                          xattr        \
+                          nfs          \
+                          pci          \
+                          3g           \
+                          wayland      \
+                          multiarch    \
+                          ptest        \
+                         "
+
+# Remove unused poky features
+DISTRO_FEATURES_remove = "zeroconf nfc x11"
+
+# Enable systemd
+DISTRO_FEATURES_append = " systemd"
+DISTRO_FEATURES_BACKFILL_CONSIDERED += "sysvinit"
+VIRTUAL-RUNTIME_init_manager = "systemd"
+VIRTUAL-RUNTIME_initscripts = "systemd-compat-units"

--- a/recipes-core/images/core-image-pelux.bb
+++ b/recipes-core/images/core-image-pelux.bb
@@ -4,13 +4,35 @@
 
 DESCRIPTION = "Image for creating a Pelux image"
 
-require recipes-core/images/core-image-bistro-dev.bb
+inherit core-image
 
 # Pelux components
 IMAGE_INSTALL += "softwarecontainer"
+IMAGE_INSTALL += "packagegroup-bistro-utils"
 
 # GENIVI components
 IMAGE_INSTALL += " dlt-daemon         \
                    dlt-daemon-systemd \
                    node-state-manager \
                  "
+
+IMAGE_FEATURES += "ssh-server-openssh tools-debug package-management"
+
+# Include bluetooth if the machine supports it (MACHINE_FEATURES), and it has
+# been selected in DISTRO_FEATURES.
+IMAGE_INSTALL += "\
+    ${@bb.utils.contains("COMBINED_FEATURES", "bluetooth", "packagegroup-tools-bluetooth", "", d)} \
+"
+
+EXTRA_IMAGE_FEATURES_append = " debug-tweaks "
+
+TOOLCHAIN_HOST_TASK += "nativesdk-cmake"
+
+# Add "/usr/lib/cmake" to the PATH variable so that CMake can find the *Config.cmake" when FIND_PACKAGE() is called from a CMake makefile
+toolchain_create_sdk_env_script_append() {
+	echo 'export PATH=$PATH:$SDKTARGETSYSROOT/usr/lib/cmake' >> $script
+}
+
+IMAGE_ROOTFS_SIZE ?= "1000000"
+
+IMAGE_FSTYPES ?= "ext3 sdcard"


### PR DESCRIPTION
This creates a new "PELUX" distribution that is a derivative of poky.
The pelux distro file contains DISTRO_FEATURES additions and removals.

The core-image-pelux inherits the poky core-image.
IMAGE_FEATURES, IMAGE_INSTALL components and image relevant
definitions are moved to this file.

Signed-off-by: Gordan Markuš <gordan.markus@pelagicore.com>