### PR TITLE
qtapplicationmanager: Fix nativesdk build

### DIFF
--- a/recipes-qt/automotive/qtapplicationmanager_git.bbappend
+++ b/recipes-qt/automotive/qtapplicationmanager_git.bbappend
@@ -12,7 +12,7 @@ SRC_URI += " \
     file://sc-config.yaml \
     "
 
-do_install_append(){
+do_install_append_class-target() {
     install -d ${D}${libdir}
     install -m 755 ${B}/examples/softwarecontainer-plugin/libsoftwarecontainer-plugin.so ${D}/usr/lib/
     install ${WORKDIR}/sc-config.yaml ${D}/opt/am/


### PR DESCRIPTION
The nativesdk build was broken because the do_install_append
instructions were valid for the nativesdk version of the recipe. Though
the nativesdk version of the recipe does not include the examples and
the do_install step will fail if the softwarecontainer plugin is not
available.

Signed-off-by: Gordan Markuš <gordan.markus@pelagicore.com>