### PR TITLE
distro: Introduce "pelux" as distro name

### DIFF
--- a/conf/distro/pelux.conf
+++ b/conf/distro/pelux.conf
@@ -6,6 +6,9 @@
 require conf/distro/poky.conf
 
 MAINTAINER = "Gordan Markuš <gordan.markus@pelagicore.com>"
+DISTRO = "pelux"
+DISTRO_NAME = "PELUX (Built on Yocto ${DISTRO_VERSION})"
+TARGET_VENDOR = "-pelux"
 
 # Add distro features
 DISTRO_FEATURES_append = " \


### PR DESCRIPTION
This makes it easier to identify the distribution running on a target
system, and it also makes it easier to identify compatible packages in
the build directory of a system.

This patch is meant to go into the Pyro release of PELUX (Yocto 2.3).

Signed-off-by: Jonatan Pålsson <jonatan.palsson@pelagicore.com>