### PR TITLE
pango: Disable GObject introspection on aarch64

### DIFF
--- a/recipes-graphics/pango/pango_%.bbappend
+++ b/recipes-graphics/pango/pango_%.bbappend
@@ -1,0 +1,4 @@
+# GObject introspection for pango needs to run some commands on the native
+# architecture, and uses qemu for this. For aarch64, these commands cause qemu
+# to crash, so we disable introspection.
+EXTRA_OECONF_aarch64 += "--disable-introspection"


### PR DESCRIPTION
GObject introspection for pango needs to run some commands on the native architecture, and uses  qemu for this. For aarch64, these commands cause qemu to crash, so we disable introspection.