### PR TITLE
core-image-pelux: turn recipe into a class

### DIFF
--- a/classes/core-image-pelux.bbclass
+++ b/classes/core-image-pelux.bbclass
@@ -3,8 +3,6 @@
 #   SPDX-License-Identifier: MIT
 #
 
-DESCRIPTION = "Image for creating a Pelux image"
-
 inherit core-image
 
 # Pelux components

--- a/recipes-core/images/core-image-pelux-minimal.bb
+++ b/recipes-core/images/core-image-pelux-minimal.bb
@@ -1,0 +1,8 @@
+#
+#   Copyright (C) 2017 Pelagicore AB
+#   SPDX-License-Identifier: MIT
+#
+
+DESCRIPTION = "Image for creating a Pelux image"
+
+inherit core-image-pelux

--- a/recipes-core/images/core-image-pelux-qtauto.bb
+++ b/recipes-core/images/core-image-pelux-qtauto.bb
@@ -5,7 +5,7 @@
 
 DESCRIPTION = "Image for creating a Pelux image with Qt frontend"
 
-require recipes-core/images/core-image-pelux.bb
+inherit core-image-pelux
 
 # Pelux components
 IMAGE_INSTALL += " neptune-ui        \


### PR DESCRIPTION
Modify meta-pelux to make the "core-image-pelux" recipe into a bbclass,
rather than a recipe.
Having core-image-pelux be a bbclass rather than a recipe will allow us
to use the "inherit" directive in our image files, rather than the
"require" directive. "inherit" is preferred, since it does not require
us to specify the path to the bbclass.

Update the existing recipes to work with this change.