### PR TITLE
distro: introduce "process-containment" feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Dependencies
 This layer depends on:
 * poky (http://git.yoctoproject.org/cgit/cgit.cgi/poky)
 * meta-openembedded (http://cgit.openembedded.org/meta-openembedded/)
-* meta-virtualization (http://git.yoctoproject.org/cgit/cgit.cgi/meta-virtualization)
+* meta-virtualization (http://git.yoctoproject.org/cgit/cgit.cgi/meta-virtualization), if the "process-containment" distro feature has been enabled
 * meta-bistro (https://github.com/Pelagicore/meta-bistro)
 
 Branching

--- a/classes/core-image-pelux.bbclass
+++ b/classes/core-image-pelux.bbclass
@@ -6,8 +6,12 @@
 inherit core-image
 
 # Pelux components
-IMAGE_INSTALL += "softwarecontainer"
 IMAGE_INSTALL += "packagegroup-bistro-utils"
+
+# Include softwarecontainer only if the process-containment feature has been enabled
+IMAGE_INSTALL += "\
+    ${@bb.utils.contains("DISTRO_FEATURES", "process-containment", "softwarecontainer", "", d)} \
+"
 
 # Pelux templates
 IMAGE_INSTALL += "template-service"

--- a/conf/distro/pelux.conf
+++ b/conf/distro/pelux.conf
@@ -21,6 +21,7 @@ DISTRO_FEATURES_append = " \
                           largefile    \
                           opengl       \
                           pcmcia       \
+                          process-containment \
                           usbgadget    \
                           usbhost      \
                           wifi         \

--- a/recipes-qt/automotive/qtapplicationmanager-noop.inc
+++ b/recipes-qt/automotive/qtapplicationmanager-noop.inc
@@ -1,0 +1,6 @@
+#
+#   Copyright (C) 2017 Pelagicore AB
+#   SPDX-License-Identifier: MIT
+#
+
+# this file is intentionally left blank

--- a/recipes-qt/automotive/qtapplicationmanager-noop.inc
+++ b/recipes-qt/automotive/qtapplicationmanager-noop.inc
@@ -3,4 +3,9 @@
 #   SPDX-License-Identifier: MIT
 #
 
-# this file is intentionally left blank
+# this file is intentionally left blank: it is sourced by the _append recipe for
+# qtapplicationmanager when the softwarecontainer plugin is disabled. This file
+# is needed because the "require" directive would fail otherwise; and on the
+# other hand, we want to use the "require" directory (instead of just
+# "include") because we want an error to be generated if -- for any reason --
+# the qtapplicationmanager-sc.inc file is not found.

--- a/recipes-qt/automotive/qtapplicationmanager-sc.inc
+++ b/recipes-qt/automotive/qtapplicationmanager-sc.inc
@@ -1,0 +1,27 @@
+#
+#   Copyright (C) 2017 Pelagicore AB
+#   SPDX-License-Identifier: MIT
+#
+
+RDEPENDS_${PN} += "${PN}-softwarecontainer"
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+EXTRA_QMAKEVARS_PRE += "\
+    -config enable-examples \
+"
+
+SRC_URI += " \
+    file://sc-config.yaml \
+    "
+
+do_install_append_class-target() {
+    install -d ${D}${libdir}
+    install -m 755 ${B}/examples/softwarecontainer-plugin/libsoftwarecontainer-plugin.so ${D}/usr/lib/
+    install ${WORKDIR}/sc-config.yaml ${D}/opt/am/
+}
+
+FILES_SOLIBSDEV = ""
+PACKAGES =+ "${PN}-softwarecontainer"
+FILES_${PN}-softwarecontainer = "\
+	${libdir}/libsoftwarecontainer-plugin.so \
+	"

--- a/recipes-qt/automotive/qtapplicationmanager_git.bbappend
+++ b/recipes-qt/automotive/qtapplicationmanager_git.bbappend
@@ -3,25 +3,5 @@
 #   SPDX-License-Identifier: MIT
 #
 
-RDEPENDS_${PN} += "${PN}-softwarecontainer"
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
-
-EXTRA_QMAKEVARS_PRE += "\
-    -config enable-examples \
-"
-
-SRC_URI += " \
-    file://sc-config.yaml \
-    "
-
-do_install_append_class-target() {
-    install -d ${D}${libdir}
-    install -m 755 ${B}/examples/softwarecontainer-plugin/libsoftwarecontainer-plugin.so ${D}/usr/lib/
-    install ${WORKDIR}/sc-config.yaml ${D}/opt/am/
-}
-
-FILES_SOLIBSDEV = ""
-PACKAGES =+ "${PN}-softwarecontainer"
-FILES_${PN}-softwarecontainer = "\
-	${libdir}/libsoftwarecontainer-plugin.so \
-	"
+containment = "${@bb.utils.contains('DISTRO_FEATURES', 'process-containment', 'sc', 'noop', d)}"
+require qtapplicationmanager-${containment}.inc


### PR DESCRIPTION
Make the softwarecontainer package optional, by adding a DISTRO_FEATURE
flag called "process-containment".  In order to keep compatibility with
the existing images, this feature is enabled by default for the "pelux"
images.

Distributions which disable this feature will not have the
softwarecontainer package installed, and therefore might not require the
meta-virtualization layer, which is being pulled in just to satisfy the
softwarecontainer dependencies.

Fixes #33