### PR TITLE
Fix appman deps on aarch64

### DIFF
--- a/recipes-temporary-patches/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/recipes-temporary-patches/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -2,3 +2,7 @@
 # and uses qemu for this. For aarch64, these commands cause qemu to crash, so
 # we disable introspection.
 EXTRA_OECONF_aarch64 += "--disable-introspection"
+
+# Wayland support is broken, so remove this until it is fixed upstream. Fixes:
+# | make[3]: *** No rule to make target 'viewporter-protocol.c', needed by 'all'.  Stop.
+PACKAGECONFIG_remove_aarch64 = "wayland"

--- a/recipes-temporary-patches/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/recipes-temporary-patches/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -1,0 +1,4 @@
+# GObject introspection needs to run some commands on the native architecture,
+# and uses qemu for this. For aarch64, these commands cause qemu to crash, so
+# we disable introspection.
+EXTRA_OECONF_aarch64 += "--disable-introspection"

--- a/recipes-temporary-patches/librsvg/librsvg_%.bbappend
+++ b/recipes-temporary-patches/librsvg/librsvg_%.bbappend
@@ -1,0 +1,4 @@
+# GObject introspection for librsvg needs to run some commands on the native
+# architecture, and uses qemu for this. For aarch64, these commands cause qemu
+# to crash, so we disable introspection.
+EXTRA_OECONF_aarch64 += "--disable-introspection"


### PR DESCRIPTION
These patches are needed to run Neptune on Qt ApplicationManager on Qt 5.9.2 on aarch64