### PR TITLE
qtapplicationmanager: Fix expansion in inc file

### DIFF
--- a/layers/b2qt/recipes-qt/automotive/qtapplicationmanager-sc.inc
+++ b/layers/b2qt/recipes-qt/automotive/qtapplicationmanager-sc.inc
@@ -4,7 +4,10 @@
 #
 
 RDEPENDS_${PN} += "${PN}-softwarecontainer"
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+# Due to immediate expansion of variables using :=, ${PN} is not yet available
+# in this .inc-file
+FILESEXTRAPATHS_prepend := "${THISDIR}/qtapplicationmanager:"
 
 EXTRA_QMAKEVARS_PRE += "\
     -config enable-examples \


### PR DESCRIPTION
The ${PN} variable in qtapplicationmanager-sc.inc does not appear to
expand properly when it is being assigned using the := operator, so
expand it manually