### PR TITLE
Remove template service from pelux bbclass

### DIFF
--- a/classes/core-image-pelux.bbclass
+++ b/classes/core-image-pelux.bbclass
@@ -13,9 +13,6 @@ IMAGE_INSTALL += "\
     ${@bb.utils.contains("DISTRO_FEATURES", "process-containment", "softwarecontainer", "", d)} \
 "
 
-# Pelux templates
-IMAGE_INSTALL += "template-service"
-
 # GENIVI components
 IMAGE_INSTALL += " dlt-daemon         \
                    dlt-daemon-systemd \

--- a/layers/template-layer/core-image-pelux-template.bb
+++ b/layers/template-layer/core-image-pelux-template.bb
@@ -1,0 +1,10 @@
+#
+#   Copyright (C) 2017 Pelagicore AB
+#   SPDX-License-Identifier: MIT
+#
+
+DESCRIPTION = "PELUX image that contains the template service"
+
+inherit core-image-pelux
+
+IMAGE_INSTALL += "template-service"


### PR DESCRIPTION
Also adds an image with the template service installed on it.

Closes #32 

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>