### PR TITLE
bsp layers: update available image names

### DIFF
--- a/meta-intel-extras/conf-qt/conf-notes.txt
+++ b/meta-intel-extras/conf-qt/conf-notes.txt
@@ -1,5 +1,5 @@
 Available PELUX images:
-* core-image-pelux
-* core-image-pelux-qtauto
+* core-image-pelux-minimal
+* core-image-pelux-qtauto-neptune
 
 Build them by running: bitbake <image>

--- a/meta-intel-extras/conf/conf-notes.txt
+++ b/meta-intel-extras/conf/conf-notes.txt
@@ -1,4 +1,4 @@
 Available PELUX images:
-* core-image-pelux
+* core-image-pelux-minimal
 
 Build them by running: bitbake <image>

--- a/meta-rpi-extras/conf-qt/conf-notes.txt
+++ b/meta-rpi-extras/conf-qt/conf-notes.txt
@@ -1,5 +1,4 @@
 Available PELUX images:
-* core-image-pelux
-* core-image-pelux-qtauto
+* core-image-pelux-minimal
 
 Build them by running: bitbake <image>

--- a/meta-rpi-extras/conf/conf-notes.txt
+++ b/meta-rpi-extras/conf/conf-notes.txt
@@ -1,4 +1,4 @@
 Available PELUX images:
-* core-image-pelux
+* core-image-pelux-minimal
 
 Build them by running: bitbake <image>


### PR DESCRIPTION
qtauto does not yet work with rpi, that's why that image isn't listed in
the conf-notes yet.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>