### PR TITLE
bblayers.conf: remove meta-qt5 unless QtAS

### DIFF
--- a/meta-intel-extras/conf/bblayers.conf.sample
+++ b/meta-intel-extras/conf/bblayers.conf.sample
@@ -21,7 +21,6 @@ BBLAYERS ?= "                                         \
   ${BSPDIR}/sources/meta-virtualization               \
   ${BSPDIR}/sources/meta-bistro                       \
   ${BSPDIR}/sources/meta-template                     \
-  ${BSPDIR}/sources/meta-qt5                          \
   "
 
 

--- a/meta-rpi-extras/conf/bblayers.conf.sample
+++ b/meta-rpi-extras/conf/bblayers.conf.sample
@@ -21,7 +21,6 @@ BBLAYERS ?= "                                         \
   ${BSPDIR}/sources/meta-virtualization               \
   ${BSPDIR}/sources/meta-bistro                       \
   ${BSPDIR}/sources/meta-template                     \
-  ${BSPDIR}/sources/meta-qt5                          \
   "
 
 


### PR DESCRIPTION
We only need meta-qt5 in our bblayers.conf if we want to build with Qt,
meaning that we want to build the QtAS variant of PELUX. In all other
cases we don't need any Qt support.

Closes #51 

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>