### PR TITLE
Remove package-bistro-utils from bbclass

### DIFF
--- a/classes/core-image-pelux.bbclass
+++ b/classes/core-image-pelux.bbclass
@@ -5,9 +5,6 @@
 
 inherit core-image
 
-# Pelux components
-IMAGE_INSTALL += "packagegroup-bistro-utils"
-
 # Include softwarecontainer only if the process-containment feature has been enabled
 IMAGE_INSTALL += "\
     ${@bb.utils.contains("DISTRO_FEATURES", "process-containment", "softwarecontainer", "", d)} \

--- a/layers/b2qt/recipes-core/images/core-image-pelux-qtauto-neptune-dev.bb
+++ b/layers/b2qt/recipes-core/images/core-image-pelux-qtauto-neptune-dev.bb
@@ -1,0 +1,10 @@
+#
+#   Copyright (C) 2017 Pelagicore AB
+#   SPDX-License-Identifier: MIT
+#
+
+DESCRIPTION = "Reference PELUX image with QtAuto frontend"
+
+require core-image-pelux-qtauto-neptune.bb
+
+IMAGE_INSTALL += " packagegroup-bistro-utils" 

--- a/recipes-core/images/core-image-pelux-minimal-dev.bb
+++ b/recipes-core/images/core-image-pelux-minimal-dev.bb
@@ -1,0 +1,9 @@
+#
+#   Copyright (C) 2017 Pelagicore AB
+#   SPDX-License-Identifier: MIT
+#
+
+require core-image-pelux-minimal.bb
+
+# Pelux components
+IMAGE_INSTALL += " packagegroup-bistro-utils"


### PR DESCRIPTION
Utils like vim and sftpserver should not be installed in the minimal
version of pelux.

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>