### PR TITLE
Splits debug-tweaks and tools-debug to -dev images

### DIFF
--- a/classes/core-image-pelux.bbclass
+++ b/classes/core-image-pelux.bbclass
@@ -16,15 +16,13 @@ IMAGE_INSTALL += " dlt-daemon         \
                    node-state-manager \
                  "
 
-IMAGE_FEATURES += "ssh-server-openssh tools-debug package-management"
+IMAGE_FEATURES += "ssh-server-openssh package-management"
 
 # Include bluetooth if the machine supports it (MACHINE_FEATURES), and it has
 # been selected in DISTRO_FEATURES.
 IMAGE_INSTALL += "\
     ${@bb.utils.contains("COMBINED_FEATURES", "bluetooth", "packagegroup-tools-bluetooth", "", d)} \
 "
-
-EXTRA_IMAGE_FEATURES_append = " debug-tweaks "
 
 TOOLCHAIN_HOST_TASK += "nativesdk-cmake"
 
@@ -34,5 +32,4 @@ toolchain_create_sdk_env_script_append() {
 }
 
 IMAGE_ROOTFS_SIZE ?= "1000000"
-
 IMAGE_FSTYPES ?= "ext3 sdcard"

--- a/layers/b2qt/recipes-core/images/core-image-pelux-qtauto-neptune-dev.bb
+++ b/layers/b2qt/recipes-core/images/core-image-pelux-qtauto-neptune-dev.bb
@@ -7,4 +7,7 @@ DESCRIPTION = "Reference PELUX image with QtAuto frontend"
 
 require core-image-pelux-qtauto-neptune.bb
 
-IMAGE_INSTALL += " packagegroup-bistro-utils" 
+# Development stuff
+IMAGE_FEATURES += "tools-debug debug-tweaks"
+IMAGE_INSTALL += " packagegroup-bistro-utils"
+

--- a/recipes-core/images/core-image-pelux-minimal-dev.bb
+++ b/recipes-core/images/core-image-pelux-minimal-dev.bb
@@ -5,5 +5,6 @@
 
 require core-image-pelux-minimal.bb
 
-# Pelux components
+# Development stuff
+IMAGE_FEATURES += "tools-debug debug-tweaks"
 IMAGE_INSTALL += " packagegroup-bistro-utils"


### PR DESCRIPTION
These features are typically only needed in a development scenario, so
they should only go into the development images.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>