### PR TITLE
Prepare the rpi for Qt Auto

### DIFF
--- a/layers/b2qt/recipes-qt/automotive/neptune-ui/neptune.service
+++ b/layers/b2qt/recipes-qt/automotive/neptune-ui/neptune.service
@@ -4,7 +4,7 @@ After=dbus-session@root.service
 Requires=dbus-session@root.service
 
 [Service]
-ExecStart=/usr/bin/appman -r -c /opt/am/sc-config.yaml -c am-config.yaml --dbus session Main.qml -platform eglfs
+ExecStart=/usr/bin/appman -r -c am-config.yaml --dbus session -platform eglfs $EXTRA_ARGUMENTS
 Restart=on-failure
 WorkingDirectory=/opt/neptune
 Environment=HOME=/home/%u/

--- a/layers/b2qt/recipes-qt/automotive/neptune-ui_git.bbappend
+++ b/layers/b2qt/recipes-qt/automotive/neptune-ui_git.bbappend
@@ -10,3 +10,24 @@ RDEPENDS_${PN}_append = "\
       qtwebengine        \
       qtquickcontrols2   \
       "
+
+HAS_CONTAINMENT = "${@bb.utils.contains('DISTRO_FEATURES', 'process-containment', '-c /opt/am/sc-config.yaml', '', d)}"
+
+#
+# Add software-container AM config to appman cmdline if we have containment
+# support
+#
+do_install_prepend() {
+    sed -i -e "s|\$EXTRA_ARGUMENTS|${HAS_CONTAINMENT}|" ${WORKDIR}/neptune.service
+}
+
+#
+# If we are installing on a rpi3, we need to force wayland to use the broadcom
+# driver when starting appman with neptune.
+#
+do_install_prepend_rpi() {
+    ENV_LINE="Environment=QT_WAYLAND_HARDWARE_INTEGRATION=brcm"
+    if ! grep -q "$ENV_LINE" "${WORKDIR}/neptune.service"; then
+        sed -i -e "/^\[Install\]$/i $ENV_LINE" ${WORKDIR}/neptune.service
+    fi
+}

--- a/layers/b2qt/recipes-qt/qt5/qtbase_%.bbappend
+++ b/layers/b2qt/recipes-qt/qt5/qtbase_%.bbappend
@@ -1,0 +1,5 @@
+
+#
+# Remove gbm support if we're building for rpi
+#
+PACKAGECONFIG_remove_rpi = "gbm"

--- a/layers/b2qt/recipes-qt/qt5/qtwayland_%.bbappend
+++ b/layers/b2qt/recipes-qt/qt5/qtwayland_%.bbappend
@@ -1,0 +1,4 @@
+#
+# Make sure we build with support for the broadcom driver if building for rpi
+#
+PACKAGECONFIG_append_rpi = " wayland-brcm "

--- a/meta-rpi-extras/recipes-bsp/boot-files/rpi-config_%.bbappend
+++ b/meta-rpi-extras/recipes-bsp/boot-files/rpi-config_%.bbappend
@@ -1,0 +1,8 @@
+
+#
+# Reserve 512MB RAM for the GPU if this is the QtAS variant, otherwise 128MB
+#
+# This checks if the b2qt layer is included.
+#
+
+GPU_MEM="${@bb.utils.contains("BBFILE_COLLECTIONS", "b2qt", 512, 128, d)}"


### PR DESCRIPTION
Perhaps the qtwayland thing should be upstreamed to the qt layers, it could easily be solved with a check on MACHINE and MACHINE_FEATURES or something like that.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>