### PR TITLE
conf/layer.conf: add a variable with the URL of the PELUX git repo

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -6,6 +6,9 @@
 # We have a conf and classes directory, append to BBPATH
 BBPATH .= ":${LAYERDIR}"
 
+# URL of the git server hosting PELUX projects
+PELUX_GIT_URL ?= "https://github.com/Pelagicore"
+
 # We have a recipes directory, add to BBFILES
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
 


### PR DESCRIPTION
This variable can be used by this layer's recipes like this:

SRC_URI = "${PELUX_GIT_URL}/project"

in order to continue working unmodified when the URL of the server
changes.

Signed-off-by: Alberto Mardegan <amardegan@luxoft.com>