### PR TITLE
conf/variant: fixes an issue with BBPATH

### DIFF
--- a/conf/variant/intel-qtauto/bblayers.conf.sample
+++ b/conf/variant/intel-qtauto/bblayers.conf.sample
@@ -1,6 +1,6 @@
 # These are needed for bitbake to pick up the includes
 BSPDIR := "${TOPDIR}/.."
-BBPATH .= ":${BSPDIR}/sources/meta-pelux"
+BBPATH := "${TOPDIR}:${BSPDIR}/sources/meta-pelux"
 
 require conf/variant/common/bblayers.conf
 require conf/variant/common/bblayers-qtauto.conf

--- a/conf/variant/intel/bblayers.conf.sample
+++ b/conf/variant/intel/bblayers.conf.sample
@@ -1,6 +1,6 @@
 # These are needed in order to make bitbake pick up the includes
 BSPDIR := "${TOPDIR}/.."
-BBPATH .= ":${BSPDIR}/sources/meta-pelux"
+BBPATH := "${TOPDIR}:${BSPDIR}/sources/meta-pelux"
 
 require conf/variant/common/bblayers.conf
 

--- a/conf/variant/rpi-qtauto/bblayers.conf.sample
+++ b/conf/variant/rpi-qtauto/bblayers.conf.sample
@@ -1,6 +1,6 @@
 # This is needed for bitbake to pick up the includes
 BSPDIR := "${TOPDIR}/.."
-BBPATH .= ":${BSPDIR}/sources/meta-pelux"
+BBPATH := "${TOPDIR}:${BSPDIR}/sources/meta-pelux"
 
 require conf/variant/common/bblayers.conf
 require conf/variant/common/bblayers-qtauto.conf

--- a/conf/variant/rpi/bblayers.conf.sample
+++ b/conf/variant/rpi/bblayers.conf.sample
@@ -1,6 +1,6 @@
 # This is needed for bitbake to pick up the includes
 BSPDIR := "${TOPDIR}/.."
-BBPATH .= ":${BSPDIR}/sources/meta-pelux"
+BBPATH := "${TOPDIR}:${BSPDIR}/sources/meta-pelux"
 
 require conf/variant/common/bblayers.conf
 


### PR DESCRIPTION
Apparently, the variant inclusion and BBPATH settings were wrong, which
for some reason never showed up while testing the variant concept
initially. This makes sure the BBPATH is sane (no empty paths in it) and
that local.conf is found properly.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>