### PR TITLE
rpi-config: Enable UART

### DIFF
--- a/meta-rpi-extras/recipes-bsp/boot-files/rpi-config_%.bbappend
+++ b/meta-rpi-extras/recipes-bsp/boot-files/rpi-config_%.bbappend
@@ -6,3 +6,9 @@
 #
 
 GPU_MEM="${@bb.utils.contains("BBFILE_COLLECTIONS", "b2qt", 512, 128, d)}"
+
+#
+# This option, together with the kernel serial command line parameter (in
+# commandline.txt) enables serial console from the kernel.
+#
+ENABLE_UART="1"


### PR DESCRIPTION
This allows connecting a serial console to the serial pins of the
raspberry pi.

Signed-off-by: Jonatan Pålsson <jonatan.palsson@pelagicore.com>