### PR TITLE
fix for qmake in sdk

### DIFF
--- a/conf/variant/common/local.conf
+++ b/conf/variant/common/local.conf
@@ -10,3 +10,6 @@ PARALLEL_MAKE ?= "-j ${@oe.utils.cpu_count()}"
 PACKAGE_CLASSES ?= "package_rpm"
 
 BB_DANGLINGAPPENDS_WARNONLY = "1"
+
+# Fix for rpm metadata clash between nativesdk-cmake and nativesdk-qtbase-tools
+DIRFILES_pn-nativesdk-cmake = "1"

--- a/layers/b2qt/recipes-core/images/core-image-pelux-qtauto-neptune.bb
+++ b/layers/b2qt/recipes-core/images/core-image-pelux-qtauto-neptune.bb
@@ -6,6 +6,7 @@
 DESCRIPTION = "Reference PELUX image with QtAuto frontend"
 
 inherit core-image-pelux-qtauto
+inherit populate_sdk_qt5
 
 # This image uses neptune as the reference UI
 IMAGE_INSTALL += " neptune-ui "


### PR DESCRIPTION
The purpose of this PR is to add Qt tools to the SDK produced when running
```bash
bitbake -c populate_sdk core-image-peulx-qtauto-neptune
```

This requrires fixing a conflict in meta-data produced by cmake and qmake when building
the rpms for the SDK. 

The fix is setting `DIRFILES = "1"`. However this only work in `local.conf` and in distro `.conf` but not in `cmake_%.bbappend`