### PR TITLE
systemd-networkd: add default DHCP for ethernet

### DIFF
--- a/recipes-core/systemd/systemd/10-pelux-ethernet.network
+++ b/recipes-core/systemd/systemd/10-pelux-ethernet.network
@@ -1,0 +1,6 @@
+[Match]
+Name=en*
+Name=eth*
+
+[Network]
+DHCP=yes

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,11 @@
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+# This sets up a default ethernet on DHCP
+SRC_URI += "file://10-pelux-ethernet.network"
+
+# We also make sure resolv.conf is using systemd-resolved
+do_install_append() {
+    install -m 0644 ${WORKDIR}/10-pelux-ethernet.network ${D}${sysconfdir}/systemd/network/10-pelux-ethernet.network
+    ln -s /run/systemd/resolve/resolv.conf ${D}${sysconfdir}/resolv.conf
+}


### PR DESCRIPTION
Will bring up any ethernet device by default by using DHCP, and also
sets up resolv.conf in a way so that both systemd and non-systemd aware
applications will work.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>