### PR TITLE
Swupdate basic integration

### DIFF
--- a/classes/core-image-pelux.bbclass
+++ b/classes/core-image-pelux.bbclass
@@ -25,6 +25,11 @@ IMAGE_INSTALL += "\
     node-state-manager \
 "
 
+# OTA mechanism
+IMAGE_INSTALL += "\
+    swupdate \
+"
+
 TOOLCHAIN_HOST_TASK += "nativesdk-cmake"
 
 # Add "/usr/lib/cmake" to the PATH variable so that CMake can find the *Config.cmake" when FIND_PACKAGE() is called from a CMake makefile

--- a/conf/variant/common/bblayers.conf
+++ b/conf/variant/common/bblayers.conf
@@ -9,6 +9,7 @@ BBLAYERS ?= "                                         \
   ${BSPDIR}/sources/meta-openembedded/meta-networking \
   ${BSPDIR}/sources/meta-openembedded/meta-python     \
   ${BSPDIR}/sources/meta-openembedded/meta-multimedia \
+  ${BSPDIR}/sources/meta-swupdate                     \
   ${BSPDIR}/sources/meta-ivi/meta-ivi                 \
   ${BSPDIR}/sources/meta-ivi/meta-ivi-bsp             \
   ${BSPDIR}/sources/meta-pelux                        \


### PR DESCRIPTION
This PR just includes the swupdate binary to the default PELUX image. It has been tested to compile and it doesn't break anything. However, swupdate hasn't been proved to be usable for upgrading yet.

Don't merge before https://github.com/Pelagicore/pelux-manifests/pull/119 is merged.