### PR TITLE
Change SDK name and version to PELUX 1.0

### DIFF
--- a/conf/distro/pelux.conf
+++ b/conf/distro/pelux.conf
@@ -8,6 +8,7 @@ require conf/distro/poky.conf
 MAINTAINER = "Gordan Markuš <gordan.markus@pelagicore.com>"
 DISTRO = "pelux"
 DISTRO_NAME = "PELUX (Built on Yocto ${DISTRO_VERSION})"
+DISTRO_VERSION = "1.0"
 TARGET_VENDOR = "-pelux"
 
 # Add distro features

--- a/conf/distro/pelux.conf
+++ b/conf/distro/pelux.conf
@@ -43,3 +43,9 @@ DISTRO_FEATURES_append = " systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED += "sysvinit"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 VIRTUAL-RUNTIME_initscripts = "systemd-compat-units"
+
+# SDK config
+SDK_NAME_PREFIX = "${DISTRO}-sdk"
+SDK_VENDOR = "-${DISTRO}sdk"
+SDKPATH = "/opt/${SDK_NAME_PREFIX}-${SDK_ARCH}/${SDK_VERSION}"
+SDK_VERSION = "${DISTRO_VERSION}"


### PR DESCRIPTION
Applying this patchet results in a: build/tmp/deploy/sdk/pelux-glibc-x86_64-core-image-pelux-minimal-cortexa7hf-neon-vfpv4-toolchain-1.0.sh
This fixes https://github.com/Pelagicore/meta-pelux/issues/90

I also changed the installation path to /opt/pelux-sdk-x86_64/1.0 which, I believe, makes it easier to find and maintain but let me know if you want to keep that change out.

I'll also send a PR to the software factory to reflect those changes.