### PR TITLE
swupdate on raspberrypi3: Add two missing files

### DIFF
--- a/meta-rpi-extras/recipes-support/swupdate/swupdate_%.bbappend
+++ b/meta-rpi-extras/recipes-support/swupdate/swupdate_%.bbappend
@@ -1,3 +1,3 @@
 FILESEXTRAPATHS_append := "${THISDIR}/${PN}:"
 
-RDEPENDS_${PN} += "parted util-linux-sfdisk"
+RDEPENDS_${PN} += "parted util-linux-sfdisk u-boot-fw-utils"

--- a/recipes-swupdate/swupdate/swupdate/swupdate.cfg
+++ b/recipes-swupdate/swupdate/swupdate/swupdate.cfg
@@ -1,0 +1,8 @@
+globals :
+{
+	verbose = true;
+	loglevel = 5;
+	syslog = true;
+	/* public-key-file = "test.pem";*/
+};
+

--- a/recipes-swupdate/swupdate/swupdate_%.bbappend
+++ b/recipes-swupdate/swupdate/swupdate_%.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS_append := "${THISDIR}/${PN}:"
+
+SRC_URI += " \
+     file://swupdate.cfg \
+     "
+
+do_install_append() {
+    install -d ${D}${sysconfdir}
+    install -m 644 ${WORKDIR}/swupdate.cfg ${D}${sysconfdir}
+}


### PR DESCRIPTION
swupdate refuses to run without an /etc/swupdate.cfg. This patchset provides a minimal configuration file that is common and useful for all devices.
Also, the u-boot-fw-utils runtime dependency on the raspberrypi wasn't properly defined by the meta-swupdate's recipe https://github.com/sbabic/meta-swupdate/blob/master/recipes-support/swupdate/swupdate.inc#L77 while I thought it was. This makes sure fw_setenv is included in the generated rootfs.

This patchset has been tested to work.