### PR TITLE
core-image-pelux: append swupdate only for rpi

### DIFF
--- a/classes/core-image-pelux.bbclass
+++ b/classes/core-image-pelux.bbclass
@@ -26,7 +26,7 @@ IMAGE_INSTALL += "\
 "
 
 # OTA mechanism
-IMAGE_INSTALL += "\
+IMAGE_INSTALL_append_rpi += "\
     swupdate \
 "
 


### PR DESCRIPTION
This commit is needed to be able to run the smoke tests.

Signed-off-by: Therese Nordqvist <therese.nordqvist@pelagicore.com>