### PR TITLE
Add powerbutton script as append to acpi

### DIFF
--- a/meta-intel-extras/recipes-bsp/acpid/acpid_2.%.bbappend
+++ b/meta-intel-extras/recipes-bsp/acpid/acpid_2.%.bbappend
@@ -1,0 +1,12 @@
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "\
+    file://powerbtn \
+    file://powerbtn.sh \
+"
+
+do_install_append() {
+    install -m 0755 ${WORKDIR}/powerbtn.sh ${D}${sysconfdir}/acpi/powerbtn.sh
+    install -m 0644 ${WORKDIR}/powerbtn ${D}${sysconfdir}/acpi/events/powerbtn
+}

--- a/meta-intel-extras/recipes-bsp/acpid/files/powerbtn
+++ b/meta-intel-extras/recipes-bsp/acpid/files/powerbtn
@@ -1,0 +1,2 @@
+event=button[ /]power
+action=/etc/acpi/powerbtn.sh

--- a/meta-intel-extras/recipes-bsp/acpid/files/powerbtn.sh
+++ b/meta-intel-extras/recipes-bsp/acpid/files/powerbtn.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Initiates a shutdown when the power putton has been pressed.
+
+/sbin/shutdown -h now "Power button pressed"
+


### PR DESCRIPTION
We want the NUC to respond to power button presses, this is done by
adding an acpi rule with a corresponding script as action, causing the
system to shutdown on press.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>