### PR TITLE
Introduction of DISTRO_FEATURES "webengine" in pelux

### DIFF
--- a/conf/distro/pelux.conf
+++ b/conf/distro/pelux.conf
@@ -34,6 +34,7 @@ DISTRO_FEATURES_append = " \
                           wayland      \
                           wifi         \
                           xattr        \
+                          webengine    \
                          "
 
 # Remove unused poky features

--- a/layers/b2qt/recipes-qt/automotive/neptune-ui_git.bbappend
+++ b/layers/b2qt/recipes-qt/automotive/neptune-ui_git.bbappend
@@ -7,7 +7,6 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 RDEPENDS_${PN}_append = "\
       dbus-session       \
-      qtwebengine        \
       qtquickcontrols2   \
       "
 


### PR DESCRIPTION
DISTRO_FEATURE "webengine" is used to enable or disable the use of
qtwebengine in pelux distro.