### PR TITLE
Introduced QtAS packagegroups in PELUX

### DIFF
--- a/classes/core-image-pelux-qtauto.bbclass
+++ b/classes/core-image-pelux-qtauto.bbclass
@@ -19,3 +19,6 @@ QTAUTO_COMPONENTS = " \
 IMAGE_INSTALL += " \
 	${@bb.utils.contains("BBFILE_COLLECTIONS", "b2qt", "${QTAUTO_COMPONENTS}", "", d)} \
 "
+
+TOOLCHAIN_HOST_TASK += " nativesdk-packagegroup-b2qt-automotive-qt5-toolchain-host "
+TOOLCHAIN_TARGET_TASK += " packagegroup-b2qt-automotive-qt5-toolchain-target "

--- a/layers/b2qt/recipes-core/images/core-image-pelux-qtauto-neptune.bb
+++ b/layers/b2qt/recipes-core/images/core-image-pelux-qtauto-neptune.bb
@@ -8,5 +8,5 @@ DESCRIPTION = "Reference PELUX image with QtAuto frontend"
 inherit core-image-pelux-qtauto
 inherit populate_sdk_qt5
 
-# This image uses neptune as the reference UI
-IMAGE_INSTALL += " neptune-ui "
+# This image uses neptune as the reference UI, which is one of the addons in Qt Auto packagegroup
+IMAGE_INSTALL += " packagegroup-b2qt-automotive-addons "


### PR DESCRIPTION
b2qt defines some packagegroups for QtAS addons(neptune-ui is one of the addons) as
well as packagegroups for host & target SDK. PELUX is now using these packagegroups
to introduce these QtAS addons & SDK instead of manually adding each component. One
consequence of using packagegroups from QtAS is that we are introducing additional
addons that were not part of PELUX distribution before.