### PR TITLE
Add TTYs to make sure a tty is available always

### DIFF
--- a/conf/variant/common/local.conf
+++ b/conf/variant/common/local.conf
@@ -27,3 +27,6 @@ NOISO = "1"
 
 # Removing tar.bz2 image format as it is not used. Incase of need, it can be supplied through own local.conf
 IMAGE_FSTYPES_remove = "tar.bz2"
+
+# List of ttys
+TTY_LIST = "tty2 tty3 tty4 tty5"

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -12,6 +12,13 @@ do_install_append() {
     	echo "Address=${STATIC_IP_ADDRESS}/24" >> ${D}${sysconfdir}/systemd/network/10-pelux-ethernet.network
     fi
     ln -s /run/systemd/resolve/resolv.conf ${D}${sysconfdir}/resolv.conf
+
+    # Create mutiple consoles
+    tmp="${TTY_LIST}"
+    for ttydev in $tmp ; do
+        ln -sf ${systemd_unitdir}/system/getty@.service ${D}${sysconfdir}/systemd/system/getty.target.wants/getty@$ttydev.service
+    done
 }
 
 FILES_${PN} += "/etc/resolv.conf"
+FILES_${PN} += "${sysconfdir}/systemd/system/getty.target.wants"


### PR DESCRIPTION
Currently there is only one tty which is taken up by the UI application.
Because of which debugging becomes difficult. This code change will enable having multiple
TTYs (4 TTYs as of now).

Signed-off-by: Sapan Das <SKumarDas@luxoft.com>