### PR TITLE
qtbase_%.bbappend: only match with end of line

### DIFF
--- a/layers/b2qt/recipes-temporary-patches/qt5/qtbase_%.bbappend
+++ b/layers/b2qt/recipes-temporary-patches/qt5/qtbase_%.bbappend
@@ -1,5 +1,5 @@
 
 # Rocko change, all python occurences are now python3
-do_configure_prepend() {
-    sed -i -e 's|/usr/bin/python|/usr/bin/python3|' ${S}/mkspecs/features/uikit/devices.py
+do_install_prepend() {
+    sed -i -e 's|/usr/bin/python$|/usr/bin/python3|' ${S}/mkspecs/features/uikit/devices.py
 }


### PR DESCRIPTION
The previous version led to double match if the same recipe was built
more than once. so python (unavailable => python3 (correct) => python33
(didn't work at all!).

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>