### PR TITLE
qtauto class: add qtappman static devs in the SDK

### DIFF
--- a/classes/core-image-pelux-qtauto.bbclass
+++ b/classes/core-image-pelux-qtauto.bbclass
@@ -21,4 +21,4 @@ IMAGE_INSTALL += " \
 "
 
 TOOLCHAIN_HOST_TASK += " nativesdk-packagegroup-b2qt-automotive-qt5-toolchain-host "
-TOOLCHAIN_TARGET_TASK += " packagegroup-b2qt-automotive-qt5-toolchain-target "
+TOOLCHAIN_TARGET_TASK += " packagegroup-b2qt-automotive-qt5-toolchain-target qtapplicationmanager-staticdev"


### PR DESCRIPTION
The static devs are needed when building HMIs with the SDK.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>