### PR TITLE
core-image-pelux: Include an sftp server by default

### DIFF
--- a/classes/core-image-pelux.bbclass
+++ b/classes/core-image-pelux.bbclass
@@ -5,7 +5,7 @@
 
 inherit core-image
 
-IMAGE_FEATURES += "ssh-server-openssh package-management debug-tweaks"
+IMAGE_FEATURES += "package-management debug-tweaks"
 
 # Include softwarecontainer only if the process-containment feature has been enabled
 IMAGE_INSTALL += "\

--- a/recipes-core/images/core-image-pelux-minimal-dev.bb
+++ b/recipes-core/images/core-image-pelux-minimal-dev.bb
@@ -6,5 +6,8 @@
 require core-image-pelux-minimal.bb
 
 # Development stuff
-IMAGE_FEATURES += "tools-debug tools-testapps"
-IMAGE_INSTALL += " packagegroup-bistro-debug-utils"
+IMAGE_FEATURES += "tools-debug tools-testapps ssh-server-openssh"
+IMAGE_INSTALL += "\
+    openssh-sftp-server \
+    packagegroup-bistro-debug-utils \
+"


### PR DESCRIPTION
QtCreator uses sftp deployment (instead of scp) to "Generic embedded
Linux" devices. Without including an sftp server, it fails with
"The SFTP server finished unexpectedly with exit code 127" but with that
package included, it Just Works(TM).

Signed-off-by: Florent Revest <revestflo@gmail.com>