### PR TITLE
pelux-image-update: fix path to sw-description

### DIFF
--- a/recipes-extended/images/pelux-image-update.inc
+++ b/recipes-extended/images/pelux-image-update.inc
@@ -19,7 +19,7 @@ IMAGE_DEPENDS = "${PELUXIMG}"
 SWUPDATE_IMAGES = "${PELUXIMG}"
 inherit swupdate
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/pelux-image-update/:"
+FILESEXTRAPATHS_prepend := "${THISDIR}/pelux-image-update/raspberrypi3:"
 SRC_URI = " file://sw-description "
 SRC_URI_append_raspberrypi3 = " file://emmcsetup.lua "
 


### PR DESCRIPTION
Fixed path to sw-description and added SRVREV for it to get rid of the
warnings.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>