### PR TITLE
Use neptune3-ui as the new reference ui

### DIFF
--- a/conf/variant/common/bblayers-qtauto.conf
+++ b/conf/variant/common/bblayers-qtauto.conf
@@ -1,7 +1,8 @@
 
 BBLAYERS += "\
   ${BSPDIR}/sources/meta-qt5     \
-  ${BSPDIR}/sources/meta-boot2qt \
+  ${BSPDIR}/sources/meta-boot2qt/meta-boot2qt-distro \
+  ${BSPDIR}/sources/meta-boot2qt/meta-boot2qt \
 "
 
 

--- a/layers/b2qt/recipes-qt/automotive/neptune3-ui/neptune.service
+++ b/layers/b2qt/recipes-qt/automotive/neptune3-ui/neptune.service
@@ -4,9 +4,9 @@ After=dbus-session@root.service
 Requires=dbus-session@root.service
 
 [Service]
-ExecStart=/usr/bin/appman -r -c am-config.yaml --dbus session -platform eglfs $EXTRA_ARGUMENTS
+ExecStart=/opt/neptune3/neptune3-ui -r --dbus session -c am-config.yaml -platform eglfs $EXTRA_ARGUMENTS
 Restart=on-failure
-WorkingDirectory=/usr/neptune-ui
+WorkingDirectory=/opt/neptune3
 Environment=HOME=/home/%u/
 Environment=LC_ALL=en_US
 Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/root/dbus/user_bus_socket

--- a/layers/b2qt/recipes-qt/automotive/neptune3-ui_git.bbappend
+++ b/layers/b2qt/recipes-qt/automotive/neptune3-ui_git.bbappend
@@ -7,7 +7,6 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 RDEPENDS_${PN}_append = "\
       dbus-session       \
-      qtquickcontrols2   \
       "
 
 HAS_CONTAINMENT = "${@bb.utils.contains('DISTRO_FEATURES', 'process-containment', '-c /opt/am/sc-config.yaml', '', d)}"
@@ -30,3 +29,8 @@ do_install_prepend_rpi() {
         sed -i -e "/^\[Install\]$/i $ENV_LINE" ${WORKDIR}/neptune.service
     fi
 }
+
+RDEPENDS_${PN} += " qtquickcontrols-qmlplugins "
+
+FILES_${PN}-tests += "/usr/share/qt5/tests/neptune-qmltestsrunner/neptune-qmltestsrunner"
+PACKAGES =+ "${PN}-tests"

--- a/layers/b2qt/recipes-qt/automotive/qtapplicationmanager_git.bbappend
+++ b/layers/b2qt/recipes-qt/automotive/qtapplicationmanager_git.bbappend
@@ -5,3 +5,5 @@
 
 containment = "${@bb.utils.contains('DISTRO_FEATURES', 'process-containment', 'sc', 'noop', d)}"
 require qtapplicationmanager-${containment}.inc
+
+ALLOW_EMPTY_${PN}-tools = "1"

--- a/layers/b2qt/recipes-qt/qt5/qttools_%.bbappend
+++ b/layers/b2qt/recipes-qt/qt5/qttools_%.bbappend
@@ -1,0 +1,3 @@
+# This will skip the test for clang and mark it as not found
+# It will result in qdoc not beeing build, which we don't need on the target anyway
+EXTRA_QMAKEVARS_PRE += " CONFIG+=config_clang_done "


### PR DESCRIPTION
This also adapts the bblayers-qtauto.conf to the new setup of meta-b2qt.
The neptune-ui.bbappend got renamed to neptune3-ui.bbappend and fixed.