### PR TITLE
swupdate: add parted and util-linux-sfdisk to RDEPENDS

### DIFF
--- a/meta-intel-extras/recipes-support/swupdate/swupdate_%.bbappend
+++ b/meta-intel-extras/recipes-support/swupdate/swupdate_%.bbappend
@@ -1,1 +1,3 @@
 FILESEXTRAPATHS_append := "${THISDIR}/${PN}:"
+
+RDEPENDS_${PN} += "parted util-linux-sfdisk"


### PR DESCRIPTION
Both parted and sfdisk are needed to perform swupdate on the Intel
platforms.