### PR TITLE
swupdate: update intel sw-description file

### DIFF
--- a/recipes-extended/images/pelux-image-update/intel-corei7-64/sw-description
+++ b/recipes-extended/images/pelux-image-update/intel-corei7-64/sw-description
@@ -5,7 +5,7 @@ software = {
     stable : {
         main : {
             images: ({
-                filename = "core-image-pelux-minimal-intel-corei7-64.ext3.gz";
+                filename = "%%PELUX_IMAGE_NAME_PLACEHOLDER%%";
                 compressed = true;
                 type = "raw";
                 device = "/dev/sda2";
@@ -21,7 +21,7 @@ software = {
         };
         alt : {
             images: ({
-                filename = "core-image-pelux-minimal-intel-corei7-64.ext3.gz";
+                filename = "%%PELUX_IMAGE_NAME_PLACEHOLDER%%";
                 compressed = true;
                 type = "raw";
                 device = "/dev/sda3";


### PR DESCRIPTION
Update the sw-description file to use generic pelux image name
placeholder instead of hardcoded image name.

Signed-off-by: Tariq Ansari <tansari@luxoft.com>