### PR TITLE
core-image-pelux-qtauto: add ssh and sftp servers to dev image

### DIFF
--- a/layers/b2qt/recipes-core/images/core-image-pelux-qtauto-neptune-dev.bb
+++ b/layers/b2qt/recipes-core/images/core-image-pelux-qtauto-neptune-dev.bb
@@ -8,5 +8,8 @@ DESCRIPTION = "Reference PELUX image with QtAuto frontend"
 require core-image-pelux-qtauto-neptune.bb
 
 # Development stuff
-IMAGE_FEATURES += "tools-debug tools-testapps"
-IMAGE_INSTALL += " packagegroup-bistro-debug-utils"
+IMAGE_FEATURES += "tools-debug tools-testapps ssh-server-openssh"
+IMAGE_INSTALL += "\
+	openssh-sftp-server \
+	packagegroup-bistro-debug-utils \
+"


### PR DESCRIPTION
Update core-image-pelux-qtauto-neptune-dev.bb to have ssh-server
as well as sftp-server

:Detail:
An app couldn't be installed from qt-creator due to the lack of sshd.
And Qt-creator use 'sftp' protocol to upload file to the target, therefore sftp-server should be on target as well.

Signed-off-by: Junil Kim <jjunil79.kim@lge.com>