### PR TITLE
intel: fix image install for grub-efi

### DIFF
--- a/conf/variant/intel-qtauto/local.conf.sample
+++ b/conf/variant/intel-qtauto/local.conf.sample
@@ -4,6 +4,4 @@ MACHINE = "intel-corei7-64"
 
 EFI_PROVIDER = "grub-efi"
 
-IMAGE_INSTALL_append = "\
-    grub-efi \
-"
+IMAGE_INSTALL_append = " grub-efi"

--- a/conf/variant/intel/local.conf.sample
+++ b/conf/variant/intel/local.conf.sample
@@ -6,6 +6,4 @@ EFI_PROVIDER = "grub-efi"
 
 WKS_FILE = "mkefidisk-multiboot.wks"
 
-IMAGE_INSTALL_append = "\
-    grub-efi \
-"
+IMAGE_INSTALL_append = " grub-efi"


### PR DESCRIPTION
It seems the space before grub-efi was not included as it should.

Signed-off-by: Therese Nordqvist <therese.nordqvist@pelagicore.com>