### PR TITLE
Jenkinsfile: remove arp

### DIFF
--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -25,8 +25,5 @@ parallel (
     'intel':        { buildPelux("intel",        "core-image-pelux-minimal") },
     'intel-qtauto': { buildPelux("intel-qtauto", "core-image-pelux-qtauto-neptune") },
     'rpi':          { buildPelux("rpi",          "core-image-pelux-minimal") },
-    'rpi-qtauto':   { buildPelux("rpi-qtauto",   "core-image-pelux-qtauto-neptune") },
-    'arp':          { buildPelux("arp",          "core-image-pelux-minimal") },
-    'arp-qtauto':   { buildPelux("arp-qtauto",   "core-image-pelux-qtauto-neptune") }
+    'rpi-qtauto':   { buildPelux("rpi-qtauto",   "core-image-pelux-qtauto-neptune") }
 )
-


### PR DESCRIPTION
ARP is supported, but does not need to be built in every Jenkinsbuild

Signed-off-by: Therese Nordqvist <therese.nordqvist@pelagicore.com>