### PR TITLE
Fix installation of core-image components

### DIFF
--- a/classes/core-image-pelux.bbclass
+++ b/classes/core-image-pelux.bbclass
@@ -8,25 +8,25 @@ inherit core-image
 IMAGE_FEATURES += "package-management debug-tweaks"
 
 # Include softwarecontainer only if the process-containment feature has been enabled
-IMAGE_INSTALL += "\
+IMAGE_INSTALL_append = "\
     ${@bb.utils.contains("DISTRO_FEATURES", "process-containment", "softwarecontainer", "", d)} \
 "
 
 # Include bluetooth if the machine supports it (MACHINE_FEATURES), and it has
 # been selected in DISTRO_FEATURES.
-IMAGE_INSTALL += "\
+IMAGE_INSTALL_append = "\
     ${@bb.utils.contains("COMBINED_FEATURES", "bluetooth", "packagegroup-tools-bluetooth", "", d)} \
 "
 
 # GENIVI components
-IMAGE_INSTALL += "\
+IMAGE_INSTALL_append = "\
     dlt-daemon         \
     dlt-daemon-systemd \
     node-state-manager \
 "
 
 # OTA mechanism
-IMAGE_INSTALL_append_rpi += "\
+IMAGE_INSTALL_append_rpi = "\
     swupdate \
 "
 
@@ -34,7 +34,7 @@ IMAGE_INSTALL_append_intel-corei7-64 = "\
     swupdate \
 "
 
-IMAGE_INSTALL_append_arp += "\
+IMAGE_INSTALL_append_arp = "\
     arp-driver \
     swupdate \
 "

--- a/recipes-core/images/core-image-pelux-minimal-dev.bb
+++ b/recipes-core/images/core-image-pelux-minimal-dev.bb
@@ -7,7 +7,8 @@ require core-image-pelux-minimal.bb
 
 # Development stuff
 IMAGE_FEATURES += "tools-debug tools-testapps ssh-server-openssh"
-IMAGE_INSTALL += "\
+
+IMAGE_INSTALL_append = "\
     openssh-sftp-server \
     packagegroup-bistro-debug-utils \
 "


### PR DESCRIPTION
While trying to debug a simple problem of "broken bluetooth" open for 2 months, I noticed that core-image-pelux lacked most of the basic features we could expect from it. For instance, a minimal bash was used as the init process, systemd wasn't used.
I tried to figure out what was going wrong and noticed that the poky's core-image's IMAGE_INSTALL wasn't included. It turns out that our usage of "IMAGE_INSTALL +=" overwrites [core-image's definition of "IMAGE_INSTALL ?=" ](http://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta/classes/core-image.bbclass#n70)
Replacing those " +=" with "_append =" keeps the core packages such as systemd and bluetooth kernel modules and fixes many problems.

But a question remains... PELUX has been broken for months and no one noticed anything ? What the heck ?!