### PR TITLE
linux-intel: fix SRCREV

### DIFF
--- a/meta-intel-extras/recipes-kernel/linux/linux-intel_%.bbappend
+++ b/meta-intel-extras/recipes-kernel/linux/linux-intel_%.bbappend
@@ -1,5 +1,6 @@
 #
 #   Copyright (C) 2016 Pelagicore AB
+#   Copyright (C) 2018 Luxoft Sweden AB
 #
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
@@ -8,3 +9,7 @@ SRC_URI += " \
     file://enable-veth.cfg \
     file://enable-hid-multitouch.cfg \
 "
+
+LINUX_VERSION = "4.9.116"
+KBRANCH = "4.9/yocto/base"
+SRCREV_machine = "521a610f0eab91e6f8c36c88916338e2cb36aa1c"


### PR DESCRIPTION
meta-intel currently points to nonexistent commit in meta-intel.
Temporarily fix by hardcoding SRCREV to latest stable Linux kernel
version of the 4.9 branch.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>