### PR TITLE
linux-intel: enable CAN

### DIFF
--- a/meta-intel-extras/recipes-kernel/linux/files/enable-can.cfg
+++ b/meta-intel-extras/recipes-kernel/linux/files/enable-can.cfg
@@ -1,0 +1,1 @@
+CONFIG_CAN=y

--- a/meta-intel-extras/recipes-kernel/linux/linux-intel_%.bbappend
+++ b/meta-intel-extras/recipes-kernel/linux/linux-intel_%.bbappend
@@ -1,10 +1,13 @@
 #
 #   Copyright (C) 2016 Pelagicore AB
+#   Copyright (C) 2018 Luxoft Sweden AB
 #
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
 # Additional config fragments
 SRC_URI += " \
+    file://enable-can.cfg \
     file://enable-veth.cfg \
     file://enable-hid-multitouch.cfg \
 "


### PR DESCRIPTION
Enabled Controller Area Network which is needed by the peak-can-driver.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>