### PR TITLE
gammaray: fix rpath

### DIFF
--- a/recipes-qt/automotive/gammaray_git.bbappend
+++ b/recipes-qt/automotive/gammaray_git.bbappend
@@ -1,0 +1,3 @@
+do_install_append() {
+    chrpath -d ${D}${libdir}/libgammaray_core-qt5_10-x86_64.so.2.9.0
+}


### PR DESCRIPTION
Fixes the following issue:

do_package_qa: QA Issue: package gammaray contains bad RPATH
in file .../gammaray/usr/lib/libgammaray_core-qt5_10-x86_64.so.2.9.0

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>