### PR TITLE
Parameterize variants and images to be built

### DIFF
--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -21,9 +21,14 @@ void buildPelux(String variant, String imageName) {
     }
 }
 
-parallel (
-    'intel':        { buildPelux("intel",        "core-image-pelux-minimal") },
-    'intel-qtauto': { buildPelux("intel-qtauto", "core-image-pelux-qtauto-neptune") },
-    'rpi':          { buildPelux("rpi",          "core-image-pelux-minimal") },
-    'rpi-qtauto':   { buildPelux("rpi-qtauto",   "core-image-pelux-qtauto-neptune") }
-)
+def variantMap = [:]
+def variantList = env.VARIANT_LIST.split()
+
+variantList.each {
+    def list = it.split(":")
+    variantMap["${list[0]}"] = {
+        buildPelux(list[0], list[1])
+    }
+}
+
+parallel (variantMap)


### PR DESCRIPTION
The variants and images to be built were hardcoded in
JenkinsFile. So if there was a need to add or remove
variants and images, the code needs to be changed. With
this change, a list of variant and images are defined
in Jenkins Environment, which are read dynamically in
JenkinsFile. So adding/removing variants and images do
not require code change.

Signed-off-by: Tariq Ansari <tansari@luxoft.com>