### PR TITLE
swupdate: disable systemd service

### DIFF
--- a/recipes-swupdate/swupdate/swupdate_%.bbappend
+++ b/recipes-swupdate/swupdate/swupdate_%.bbappend
@@ -8,3 +8,5 @@ do_install_append() {
     install -d ${D}${sysconfdir}
     install -m 644 ${WORKDIR}/swupdate.cfg ${D}${sysconfdir}
 }
+
+SYSTEMD_AUTO_ENABLE_${PN} = "disable"


### PR DESCRIPTION
Since we don't need swupdate service to start on system boot, disable it.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>