### PR TITLE
qtapplicationmanager: fix path to library

### DIFF
--- a/layers/b2qt/recipes-qt/automotive/qtapplicationmanager-sc.inc
+++ b/layers/b2qt/recipes-qt/automotive/qtapplicationmanager-sc.inc
@@ -1,5 +1,6 @@
 #
 #   Copyright (C) 2017 Pelagicore AB
+#   Copyright (C) 2018 Luxoft Sweden AB
 #   SPDX-License-Identifier: MIT
 #
 
@@ -13,18 +14,18 @@ EXTRA_QMAKEVARS_PRE += "\
     -config enable-examples \
 "
 
-SRC_URI += " \
+SRC_URI += "\
     file://sc-config.yaml \
-    "
+"
 
 do_install_append_class-target() {
     install -d ${D}${libdir}
-    install -m 755 ${B}/examples/softwarecontainer-plugin/libsoftwarecontainer-plugin.so ${D}/usr/lib/
+    install -m 755 ${B}/examples/applicationmanager/softwarecontainer-plugin/libsoftwarecontainer-plugin.so ${D}${libdir}
     install ${WORKDIR}/sc-config.yaml ${D}/opt/am/
 }
 
 FILES_SOLIBSDEV = ""
 PACKAGES =+ "${PN}-softwarecontainer"
 FILES_${PN}-softwarecontainer = "\
-	${libdir}/libsoftwarecontainer-plugin.so \
-	"
+    ${libdir}/libsoftwarecontainer-plugin.so \
+"


### PR DESCRIPTION
Fixed path to the library and cleaned up syntax a bit.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>