### PR TITLE
qtscript: add bbappend with temp fix for SDK

### DIFF
--- a/recipes-temporary-patches/qtscript/qtscript/lto.patch
+++ b/recipes-temporary-patches/qtscript/qtscript/lto.patch
@@ -1,0 +1,11 @@
+--- a/src/3rdparty/javascriptcore/JavaScriptCore/jit/JITStubs.h 2017-10-09 14:40:55.050363361 +0300
++++ b/src/3rdparty/javascriptcore/JavaScriptCore/jit/JITStubs.h 2017-10-09 14:45:50.271354448 +0300
+@@ -316,7 +316,7 @@
+     EncodedJSValue JIT_STUB cti_op_to_primitive(STUB_ARGS_DECLARATION);
+     EncodedJSValue JIT_STUB cti_op_typeof(STUB_ARGS_DECLARATION);
+     EncodedJSValue JIT_STUB cti_op_urshift(STUB_ARGS_DECLARATION);
+-    EncodedJSValue JIT_STUB cti_vm_throw(STUB_ARGS_DECLARATION);
++    EncodedJSValue JIT_STUB cti_vm_throw(STUB_ARGS_DECLARATION) __attribute__((used));
+     EncodedJSValue JIT_STUB cti_to_object(STUB_ARGS_DECLARATION);
+     JSObject* JIT_STUB cti_op_construct_JSConstruct(STUB_ARGS_DECLARATION);
+     JSObject* JIT_STUB cti_op_new_array(STUB_ARGS_DECLARATION);

--- a/recipes-temporary-patches/qtscript/qtscript_git.bbappend
+++ b/recipes-temporary-patches/qtscript/qtscript_git.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://lto.patch"


### PR DESCRIPTION
This fixes the following compilation issue while building SDK.

Patch has been borrowed from gentooLTO and authored by Shane Peelar.

 /tmp/ccqctduy.ltrans0.ltrans.o: In function `ctiVMThrowTrampoline':
 <artificial>:(.text+0x4c): undefined reference to `cti_vm_throw'
 collect2: error: ld returned 1 exit status