### PR TITLE
local.conf.sample: set PREFERRED_PROVIDER for iasl-native

### DIFF
--- a/conf/variant/arp-qtauto/local.conf.sample
+++ b/conf/variant/arp-qtauto/local.conf.sample
@@ -4,6 +4,8 @@ MACHINE = "arp"
 
 EFI_PROVIDER = "grub-efi"
 
+PREFERRED_PROVIDER_iasl-native = "iasl-native"
+
 WKS_FILE = "mkefidisk-multiboot.wks"
 
 IMAGE_INSTALL_append = " grub-efi"

--- a/conf/variant/arp/local.conf.sample
+++ b/conf/variant/arp/local.conf.sample
@@ -4,6 +4,8 @@ MACHINE = "arp"
 
 EFI_PROVIDER = "grub-efi"
 
+PREFERRED_PROVIDER_iasl-native = "iasl-native"
+
 WKS_FILE = "mkefidisk-multiboot.wks"
 
 IMAGE_INSTALL_append = " grub-efi"

--- a/conf/variant/intel-qtauto/local.conf.sample
+++ b/conf/variant/intel-qtauto/local.conf.sample
@@ -4,6 +4,8 @@ MACHINE = "intel-corei7-64"
 
 EFI_PROVIDER = "grub-efi"
 
+PREFERRED_PROVIDER_iasl-native = "iasl-native"
+
 WKS_FILE = "mkefidisk-multiboot.wks"
 
 IMAGE_INSTALL_append = " grub-efi"

--- a/conf/variant/intel/local.conf.sample
+++ b/conf/variant/intel/local.conf.sample
@@ -4,6 +4,8 @@ MACHINE = "intel-corei7-64"
 
 EFI_PROVIDER = "grub-efi"
 
+PREFERRED_PROVIDER_iasl-native = "iasl-native"
+
 WKS_FILE = "mkefidisk-multiboot.wks"
 
 IMAGE_INSTALL_append = " grub-efi"


### PR DESCRIPTION
Bitbake produces the following warning:

  NOTE: Multiple providers are available for iasl-native (iasl-native, acpica-native)
  Consider defining a PREFERRED_PROVIDER entry to match iasl-native

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>