### PR TITLE
Fix container & appman config files

### DIFF
--- a/layers/b2qt/recipes-qt/automotive/qtapplicationmanager/sc-config.yaml
+++ b/layers/b2qt/recipes-qt/automotive/qtapplicationmanager/sc-config.yaml
@@ -6,7 +6,7 @@ formatType: am-configuration
 ---
 containers:
   selection:
-    - com.pelagicore.radio: "softwarecontainer"
+    - com.pelagicore.calendar: "softwarecontainer"
     - "*": "process"
 
   softwarecontainer:

--- a/recipes-containers/softwarecontainer/files/io.qt.ApplicationManager.Application.json
+++ b/recipes-containers/softwarecontainer/files/io.qt.ApplicationManager.Application.json
@@ -8,6 +8,14 @@
           "id": "dbus",
           "config": [
             {
+             "dbus-gateway-config-session": [
+                {
+                  "direction": "*",
+                  "interface": "*",
+                  "object-path": "*",
+                  "method": "*"
+                }
+              ],
              "dbus-gateway-config-system": [
                 {
                   "direction": "*",

--- a/recipes-containers/softwarecontainer/files/softwarecontainer-agent.service
+++ b/recipes-containers/softwarecontainer/files/softwarecontainer-agent.service
@@ -8,6 +8,7 @@ Type=dbus
 BusName=com.pelagicore.SoftwareContainerAgent
 ExecStart=/usr/bin/softwarecontainer-agent
 Environment=XDG_RUNTIME_DIR=/tmp
+Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/root/dbus/user_bus_socket
 
 [Install]
 WantedBy=basic.target


### PR DESCRIPTION
This fix enable the Neptune3 calendar application
to run inside a Software Container. Also updated
the gateway config and environment variable for
calendar application inside the container to
access the session dbus on host to communicate
with the neptune3 ui on the host.

Signed-off-by: Tariq Ansari <tansari@luxoft.com>