### PR TITLE
conf-notes: add variant name to text

### DIFF
--- a/conf/variant/arp-qtauto/conf-notes.txt
+++ b/conf/variant/arp-qtauto/conf-notes.txt
@@ -1,4 +1,4 @@
-Available PELUX images:
+Available PELUX images for arp-qtauto:
 * core-image-pelux-minimal
 * core-image-pelux-minimal-dev
 * core-image-pelux-qtauto-neptune

--- a/conf/variant/arp/conf-notes.txt
+++ b/conf/variant/arp/conf-notes.txt
@@ -1,4 +1,4 @@
-Available PELUX images:
+Available PELUX images for arp:
 * core-image-pelux-minimal
 * core-image-pelux-minimal-dev
 

--- a/conf/variant/intel-qtauto/conf-notes.txt
+++ b/conf/variant/intel-qtauto/conf-notes.txt
@@ -1,4 +1,4 @@
-Available PELUX images:
+Available PELUX images for intel-qtauto:
 * core-image-pelux-minimal
 * core-image-pelux-minimal-dev
 * core-image-pelux-qtauto-neptune

--- a/conf/variant/intel/conf-notes.txt
+++ b/conf/variant/intel/conf-notes.txt
@@ -1,4 +1,4 @@
-Available PELUX images:
+Available PELUX images for intel:
 * core-image-pelux-minimal
 * core-image-pelux-minimal-dev
 

--- a/conf/variant/qemu-x86-64_nogfx/conf-notes.txt
+++ b/conf/variant/qemu-x86-64_nogfx/conf-notes.txt
@@ -1,4 +1,4 @@
-Available PELUX images:
+Available PELUX images for qemu-x86-64_nogfx:
 * core-image-pelux-minimal
 * core-image-pelux-minimal-dev
 

--- a/conf/variant/rpi-qtauto/conf-notes.txt
+++ b/conf/variant/rpi-qtauto/conf-notes.txt
@@ -1,4 +1,4 @@
-Available PELUX images:
+Available PELUX images for rpi-qtauto:
 * core-image-pelux-minimal
 * core-image-pelux-minimal-dev
 * core-image-pelux-qtauto-neptune

--- a/conf/variant/rpi/conf-notes.txt
+++ b/conf/variant/rpi/conf-notes.txt
@@ -1,4 +1,4 @@
-Available PELUX images:
+Available PELUX images for rpi:
 * core-image-pelux-minimal
 * core-image-pelux-minimal-dev
 


### PR DESCRIPTION
To make it clear which variant will be built, print it out when the
poky build-env is being sourced.

Signed-off-by: Therese Nordqvist <therese.nordqvist@pelagicore.com>