### PR TITLE
gammaray: make bbappend version universal

### DIFF
--- a/recipes-temporary-patches/gammaray/gammaray_git.bbappend
+++ b/recipes-temporary-patches/gammaray/gammaray_git.bbappend
@@ -1,9 +1,9 @@
 do_install_append_intel-corei7-64() {
-    chrpath -d ${D}/usr/lib/libgammaray_core-qt5_11-x86_64.so.2.9.1
+    chrpath -d ${D}${libdir}/libgammaray_core-qt5_11-x86_64.so*
 }
 
 do_install_append_raspberrypi3() {
-    chrpath -d ${D}${libdir}/libgammaray_core-qt5_11-arm.so.2.9.1
+    chrpath -d ${D}${libdir}/libgammaray_core-qt5_11-arm.so*
 }
 
 DEPENDS += "elfutils"


### PR DESCRIPTION
rpath issue has been present in gammaray for a while now. Every time
meta-qt layer updates gammaray version, we need to adjust bbappend to
use correct name of the library.

Delete current rpath setting from all the gammaray libs instead.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>
(cherry picked from commit 5c00d02653a69135ef3368d6910fd61cd2748ef1)