### PR TITLE
core-image-pelux: add coreutils to non-dev images

### DIFF
--- a/layers/b2qt/recipes-core/images/core-image-pelux-qtauto-neptune.bb
+++ b/layers/b2qt/recipes-core/images/core-image-pelux-qtauto-neptune.bb
@@ -1,5 +1,6 @@
 #
 #   Copyright (C) 2017 Pelagicore AB
+#   Copyright (C) 2018 Pelagicore AB
 #   SPDX-License-Identifier: MIT
 #
 
@@ -9,4 +10,7 @@ inherit core-image-pelux-qtauto
 inherit populate_sdk_qt5
 
 # This image uses neptune as the reference UI, which is one of the addons in Qt Auto packagegroup
-IMAGE_INSTALL += " packagegroup-b2qt-automotive-addons "
+IMAGE_INSTALL_append = "\
+    coreutils \
+    packagegroup-b2qt-automotive-addons \
+"

--- a/recipes-core/images/core-image-pelux-minimal.bb
+++ b/recipes-core/images/core-image-pelux-minimal.bb
@@ -1,8 +1,13 @@
 #
 #   Copyright (C) 2017 Pelagicore AB
+#   Copyright (C) 2018 Luxoft Sweden AB
 #   SPDX-License-Identifier: MIT
 #
 
 DESCRIPTION = "Image for creating a Pelux image"
 
 inherit core-image-pelux
+
+IMAGE_INSTALL_append = "\
+    coreutils \
+"


### PR DESCRIPTION
To avoid potentially different behaviour on dev and non-dev images,
install coreutils on non-dev images as well.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>