### PR TITLE
qtscript: disable lto on ARM

### DIFF
--- a/recipes-temporary-patches/qtscript/qtscript_git.bbappend
+++ b/recipes-temporary-patches/qtscript/qtscript_git.bbappend
@@ -1,3 +1,5 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += "file://lto.patch"
+
+EXTRA_QMAKEVARS_PRE_append_arm = " CONFIG-=ltcg"


### PR DESCRIPTION
Fixes rpi-qtauto SDK builds.

Building QtScript with GCC 7.3 for ARM with LTO results in a lot of
undefined references to JIT stubs in src/3rdparty/javascriptcore . Looks
like a GCC LTO bug when building for ARM.

QtScript has been deprecated since 5.5 so it is not an important module.
It also seems the main reason for enabling lto for Qt was size (see
c3cc11bc289363203da533e477d4f58a64a79db2 in meta-qt5).

Just disable it.

Signed-off-by: Martin Ejdestig <mejdestig@luxoft.com>
(cherry picked from commit 659686ef139cd7f7c578bc37458296a5338d9d76)