### PR TITLE
Jenkinsfile: build against analogous manifest branch

### DIFF
--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -1,9 +1,19 @@
 #!/usr/bin/groovy
 
-// Copyright (C) Luxoft Sweden AB 2018
+// Copyright (C) 2018 Luxoft Sweden AB
 
 void buildPelux(String variant, String imageName) {
     String peluxDir = "meta-pelux"
+    String branchName = "master"
+
+    // If this is a PR, CHANGE_TARGET will be set by the Pipeline Plugin,
+    // otherwise check BRANCH_NAME which is set by Jenkins
+    if (env.CHANGE_TARGET) {
+        branchName = "${env.CHANGE_TARGET}"
+    } else if (env.BRANCH_NAME) {
+        branchName = "${env.BRANCH_NAME}"
+    }
+
     node("Yocto") {
         dir(peluxDir) {
             checkout scm
@@ -11,7 +21,7 @@ void buildPelux(String variant, String imageName) {
 
         // Initialize pelux-manifests to get the code
         sh "rm -rf pelux-manifests/"
-        sh "git clone https://github.com/Pelagicore/pelux-manifests.git"
+        sh "git clone https://github.com/Pelagicore/pelux-manifests.git -b ${branchName}"
 
         dir('pelux-manifests') {
             def code = load "ci-scripts/yocto.groovy"


### PR DESCRIPTION
Currently, every pull request and branch build is built against master
branch of the pelux-manifests, which is incorrect since both meta layers
and pelux-manifests follow the Yocto branching strategy, making some of
the branches incompatible between each other.

Build the layer against the corresponding branch of the PELUX manifest
instead, e.g. sumo against sumo and master against master.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>