### PR TITLE
gammaray: remove bbappend

### DIFF
--- a/recipes-temporary-patches/gammaray/gammaray_git.bbappend
+++ b/recipes-temporary-patches/gammaray/gammaray_git.bbappend
@@ -1,9 +1,0 @@
-do_install_append_intel-corei7-64() {
-    chrpath -d ${D}${libdir}/libgammaray_core-qt5_11-x86_64.so*
-}
-
-do_install_append_raspberrypi3() {
-    chrpath -d ${D}${libdir}/libgammaray_core-qt5_11-arm.so*
-}
-
-DEPENDS += "elfutils"


### PR DESCRIPTION
Removed bbappend as the rparth issue has been finally fixed in
Gammaray 5.12.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>