### PR TITLE
qtapplicationmanager: Removed explicit hash

### DIFF
--- a/layers/b2qt/recipes-qt/automotive/qtapplicationmanager_git.bbappend
+++ b/layers/b2qt/recipes-qt/automotive/qtapplicationmanager_git.bbappend
@@ -6,6 +6,4 @@
 containment = "${@bb.utils.contains('DISTRO_FEATURES', 'process-containment', 'sc', 'noop', d)}"
 require qtapplicationmanager-${containment}.inc
 
-SRCREV = "5c08826b6c794fe67ed2ebecca4a53ecf918ecca"
-
 ALLOW_EMPTY_${PN}-tools = "1"


### PR DESCRIPTION
This fix is required to make appman and neptune 3 ui be in sync.

Since the manifest has been updated to 5.12 this patch is not
needed anymore.