### PR TITLE
core-image-pelux: temporarily remove mopidy

### DIFF
--- a/classes/core-image-pelux.bbclass
+++ b/classes/core-image-pelux.bbclass
@@ -33,9 +33,9 @@ IMAGE_INSTALL_append = "\
 "
 
 # Media playback daemon
-IMAGE_INSTALL_append = "\
-    mopidy \
-"
+#IMAGE_INSTALL_append = "\
+#    mopidy \
+#"
 
 # OTA mechanism
 IMAGE_INSTALL_append_rpi = "\


### PR DESCRIPTION
Mopidy installation is broken in thud due to python2 support being
dropped by Yocto and mopidy not suppororting python3 just yet.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>