### PR TITLE
local.conf.samples: whitelist commercial for faad2

### DIFF
--- a/conf/variant/rpi/local.conf.sample
+++ b/conf/variant/rpi/local.conf.sample
@@ -1,6 +1,7 @@
-
 require conf/variant/common/local.conf
 
 MACHINE = "raspberrypi3"
 
 RPI_USE_U_BOOT = "1"
+
+LICENSE_FLAGS_WHITELIST = "commercial_faad2"


### PR DESCRIPTION
faad2 is licensed under the GPLv2 and a commercial license for a
commercial use.

Since commercial is set in the recipe and we are not using it in the
commercial purposes, we temporarily whitelist license for faad2 package
until a better solution is found.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>