### PR TITLE
local.conf.sample: auto-load kernel modules

### DIFF
--- a/conf/variant/arp-qtauto/local.conf.sample
+++ b/conf/variant/arp-qtauto/local.conf.sample
@@ -9,3 +9,5 @@ PREFERRED_PROVIDER_iasl-native = "iasl-native"
 WKS_FILE = "mkefidisk-multiboot.wks"
 
 IMAGE_INSTALL_append = " grub-efi"
+
+KERNEL_MODULE_AUTOLOAD += "hid-multitouch video i915"

--- a/conf/variant/intel-qtauto/local.conf.sample
+++ b/conf/variant/intel-qtauto/local.conf.sample
@@ -11,3 +11,5 @@ WKS_FILE = "mkefidisk-multiboot.wks"
 IMAGE_INSTALL_append = " grub-efi"
 
 LICENSE_FLAGS_WHITELIST = "commercial_faad2"
+
+KERNEL_MODULE_AUTOLOAD += "hid-multitouch video i915"


### PR DESCRIPTION
Auto load kernel modules necessary for proper functioning of the
Neptune 3 UI.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>