### PR TITLE
grub-efi: add fstab to meta-intel to mount EFI partition 

### DIFF
--- a/meta-intel-extras/recipes-core/base-files/base-files/intel-corei7-64/fstab
+++ b/meta-intel-extras/recipes-core/base-files/base-files/intel-corei7-64/fstab
@@ -1,0 +1,3 @@
+/dev/root            /                    auto       defaults              1  1
+/dev/sda1	/boot	vfat	defaults	0	0
+/dev/sda4	swap	swap	defaults	0	0

--- a/meta-intel-extras/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-intel-extras/recipes-core/base-files/base-files_%.bbappend
@@ -1,0 +1,8 @@
+#
+#   Copyright (C) 2017 Pelagicore AB
+#   SPDX-License-Identifier: MIT
+#
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+SRC_URI += "file://fstab"
+

--- a/meta-intel-extras/recipes-support/grub/grub-efi/grubenv-copy.service
+++ b/meta-intel-extras/recipes-support/grub/grub-efi/grubenv-copy.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Service that copies grubenv to /boot/ after swupdate
+After=local-fs.target
 
 [Service]
 ExecStart=/usr/bin/grubenv-copy.sh

--- a/meta-intel-extras/recipes-support/grub/grub-efi/grubenv-copy.sh
+++ b/meta-intel-extras/recipes-support/grub/grub-efi/grubenv-copy.sh
@@ -1,9 +1,5 @@
 #!/bin/sh
 
-if [ ! -d /boot/EFI/BOOT/ ]; then
-    mount /dev/sda1 /boot
-fi
-
 if [ ! -f /boot/EFI/BOOT/grubenv ]; then
     cp /usr/share/grubenv /boot/EFI/BOOT/grubenv
 fi


### PR DESCRIPTION
A check prevented mount of EFI partition to /boot directory,
incase /boot directory already existed. This eventually result
in failing to copy the grubenv file to EFI partition. This
check is removed to fix this issue.

Signed-off-by: Tariq Ansari <tansari@luxoft.com>