### PR TITLE
python-tonado: add recipe

### DIFF
--- a/recipes-python/tornado/python-tornado45.bb
+++ b/recipes-python/tornado/python-tornado45.bb
@@ -1,0 +1,25 @@
+#
+#   Copyright (C) 2018 Koen Kooi
+#
+#   SPDX-License-Identifier: MIT
+#
+
+DESCRIPTION = "Tornado is an open source version of the scalable, non-blocking web server and tools that power FriendFeed."
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
+
+PV = "4.5.3"
+
+SRCREV = "8e9e75502ff910629663c4cdd7779d43ea2dd150"
+SRC_URI = "git://github.com/tornadoweb/tornado.git;branch=branch4.5"
+
+S = "${WORKDIR}/git"
+
+inherit setuptools
+
+DEPENDS = "python-certifi"
+
+RDEPENDS_${PN} = "python-certifi"
+RCONFLICTS_${PN} = "python-tornado"
+RCONFLICTS_${PN} = "python-tornado40"
+RCONFLICTS_${PN} = "python-tornado50"


### PR DESCRIPTION
python-tornado 4.x is needed by Mopidy. meta-oe is currently provides
version 5 only.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>