### PR TITLE
mopidy: add dependancy on python-tornado45

### DIFF
--- a/recipes-multimedia/mopidy/mopidy_2.2.2.bb
+++ b/recipes-multimedia/mopidy/mopidy_2.2.2.bb
@@ -38,5 +38,7 @@ RRECOMMENDS_${PN} = "\
     pulseaudio-module-native-protocol-tcp \
     "
 
+DEPENDS = "python-tornado45"
+
 FILES_${PN} += "${systemd_system_unitdir}/mopidy.service"
 SYSTEMD_SERVICE_${PN} = "mopidy.service"


### PR DESCRIPTION
Make sure that python-tornado v4.5 provided by meta-pelux will be
on the image instead of newer versions provided by meta-openembedded.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>