### PR TITLE
core-image-pelux: add mopidy back

### DIFF
--- a/classes/core-image-pelux.bbclass
+++ b/classes/core-image-pelux.bbclass
@@ -33,9 +33,9 @@ IMAGE_INSTALL_append = "\
 "
 
 # Media playback daemon
-#IMAGE_INSTALL_append = "\
-#    mopidy \
-#"
+IMAGE_INSTALL_append = "\
+    mopidy \
+"
 
 # OTA mechanism
 IMAGE_INSTALL_append_rpi = "\


### PR DESCRIPTION
Since mopidy installation in Thud is fixed, add it back to the image.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>