### PR TITLE
local.conf: set WIC_CREATE_EXTRA_ARGS to --no-fstab-update

### DIFF
--- a/conf/variant/arp-qtauto/local.conf.sample
+++ b/conf/variant/arp-qtauto/local.conf.sample
@@ -7,5 +7,6 @@ EFI_PROVIDER = "grub-efi"
 PREFERRED_PROVIDER_iasl-native = "iasl-native"
 
 WKS_FILE = "mkefidisk-multiboot.wks"
+WIC_CREATE_EXTRA_ARGS = "--no-fstab-update"
 
 IMAGE_INSTALL_append = " grub-efi"

--- a/conf/variant/arp/local.conf.sample
+++ b/conf/variant/arp/local.conf.sample
@@ -7,5 +7,6 @@ EFI_PROVIDER = "grub-efi"
 PREFERRED_PROVIDER_iasl-native = "iasl-native"
 
 WKS_FILE = "mkefidisk-multiboot.wks"
+WIC_CREATE_EXTRA_ARGS = "--no-fstab-update"
 
 IMAGE_INSTALL_append = " grub-efi"

--- a/conf/variant/intel-qtauto/local.conf.sample
+++ b/conf/variant/intel-qtauto/local.conf.sample
@@ -7,5 +7,6 @@ EFI_PROVIDER = "grub-efi"
 PREFERRED_PROVIDER_iasl-native = "iasl-native"
 
 WKS_FILE = "mkefidisk-multiboot.wks"
+WIC_CREATE_EXTRA_ARGS = "--no-fstab-update"
 
 IMAGE_INSTALL_append = " grub-efi"

--- a/conf/variant/intel/local.conf.sample
+++ b/conf/variant/intel/local.conf.sample
@@ -7,5 +7,6 @@ EFI_PROVIDER = "grub-efi"
 PREFERRED_PROVIDER_iasl-native = "iasl-native"
 
 WKS_FILE = "mkefidisk-multiboot.wks"
+WIC_CREATE_EXTRA_ARGS = "--no-fstab-update"
 
 IMAGE_INSTALL_append = " grub-efi"


### PR DESCRIPTION
A wks file used to create dual boot partitions was used to
automatically create an fstab file with mount entries for
the partitions. But since an fstab file already existed with
those entries, so it appended the new entries, resulting in
duplicate entries. Setting --no-fstab-update will ignore
generating the fstab file automatically.

Signed-off-by: Tariq Ansari <tansari@luxoft.com>