### PR TITLE
local.conf.samples: whitelist commercial for faad2 on ARP

### DIFF
--- a/conf/variant/arp-qtauto/local.conf.sample
+++ b/conf/variant/arp-qtauto/local.conf.sample
@@ -10,4 +10,6 @@ WKS_FILE = "mkefidisk-multiboot.wks"
 
 IMAGE_INSTALL_append = " grub-efi"
 
+LICENSE_FLAGS_WHITELIST = "commercial_faad2"
+
 KERNEL_MODULE_AUTOLOAD += "hid-multitouch video i915"

--- a/conf/variant/arp/local.conf.sample
+++ b/conf/variant/arp/local.conf.sample
@@ -9,3 +9,5 @@ PREFERRED_PROVIDER_iasl-native = "iasl-native"
 WKS_FILE = "mkefidisk-multiboot.wks"
 
 IMAGE_INSTALL_append = " grub-efi"
+
+LICENSE_FLAGS_WHITELIST = "commercial_faad2"


### PR DESCRIPTION
faad2 is licensed under the GPLv2 and a commercial license for a
commercial use, therefore LICENSE_FLAGS is set to "commercial" in the
recipe.

The "commercial" license has been whitelisted for Intel and RPI3 in
@49178fb4c8b2fb77. Whitelist it for ARP as well.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>