### PR TITLE
neptune3: Force to run as single process for rpi

### DIFF
--- a/layers/b2qt/recipes-qt/automotive/neptune3-ui_git.bbappend
+++ b/layers/b2qt/recipes-qt/automotive/neptune3-ui_git.bbappend
@@ -11,6 +11,7 @@ RDEPENDS_${PN}_append = "\
       "
 
 HAS_CONTAINMENT = "${@bb.utils.contains('DISTRO_FEATURES', 'process-containment', '-c /opt/am/sc-config.yaml', '', d)}"
+FORCE_SINGLE_PROCESS = "${@bb.utils.contains('MACHINE', 'raspberrypi3', ' --force-single-process', '', d)}"
 
 #
 # Add software-container AM config to appman cmdline if we have containment support
@@ -21,7 +22,7 @@ do_install_prepend() {
     git lfs pull
     cd -
 
-    sed -i -e "s|\$EXTRA_ARGUMENTS|${HAS_CONTAINMENT}|" ${WORKDIR}/neptune.service
+    sed -i -e "s|\$EXTRA_ARGUMENTS|${HAS_CONTAINMENT}${FORCE_SINGLE_PROCESS}|" ${WORKDIR}/neptune.service
 }
 
 #


### PR DESCRIPTION
With neptune3, multiple applications in neptune ui
runs as separate processes. On rpi this causes some
performance issues since it doesn't have a very good
GPU. This causes a very low frame rate as well as
issues with correct rendering of the applications.
A workaround is added which runs neptune3 ui as a
single process. This fixes the performance and
rendering issues on rpi. This is a temporary fix,
until a solution is provided in neptune for this
issue.

Signed-off-by: Tariq Ansari <tansari@luxoft.com>
(cherry picked from commit 1f81027db7c94c13b0cc1aeb03c86e2f4bc4db31)