### PR TITLE
core-image-pelux.bbclass: add portaudio

### DIFF
--- a/classes/core-image-pelux.bbclass
+++ b/classes/core-image-pelux.bbclass
@@ -28,6 +28,7 @@ IMAGE_INSTALL_append = "\
 
 # Alexa SDK
 IMAGE_INSTALL_append = "\
+    portaudio-v19      \
     avs-device-sdk     \
 "
 


### PR DESCRIPTION
portaudio and snowboy are required for Alexa sample
application to run. portaudio is used for microphone
input and snowboy implements wake word detector for
Alexa sample application.

Signed-off-by: Tariq Ansari <tansari@luxoft.com>