### PR TITLE
core-image-pelux: add avs-device-sdk

### DIFF
--- a/classes/core-image-pelux.bbclass
+++ b/classes/core-image-pelux.bbclass
@@ -26,6 +26,11 @@ IMAGE_INSTALL_append = "\
     node-state-manager \
 "
 
+# Alexa SDK
+IMAGE_INSTALL_append = "\
+    avs-device-sdk     \
+"
+
 # CAN utilities
 IMAGE_INSTALL_append = "\
     libsocketcan \


### PR DESCRIPTION
avs-device-sdk is needed for development of Alexa
voice service applications on PELUX.

Signed-off-by: Tariq Ansari <tansari@luxoft.com>