### PR TITLE
qt: Move qt to qt5.12

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -13,7 +13,8 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
 BBFILE_COLLECTIONS += "pelux-layer"
 BBFILE_PATTERN_pelux-layer := "^${LAYERDIR}/"
 
-BBFILE_PRIORITY_pelux-layer = "8"
+# We need a higher priority then boot2qt
+BBFILE_PRIORITY_pelux-layer = "21"
 
 # Let us add layer-specific bbappends which are only applied when that
 # layer is included in our configuration

--- a/conf/variant/common/bblayers.conf
+++ b/conf/variant/common/bblayers.conf
@@ -17,4 +17,9 @@ BBLAYERS ?= "                                          \
   ${BSPDIR}/sources/meta-virtualization                \
 "
 
+# Workaround to build b2qt and qt5.12 with rocko
+LAYERSERIES_CORENAMES_append = " rocko"
+LAYERSERIES_COMPAT_b2qt_append = " rocko"   
+LAYERSERIES_COMPAT_b2qt-distro_append = " rocko"  
+
 LCONF_VERSION = "7"

--- a/conf/variant/rpi-qtauto/local.conf.sample
+++ b/conf/variant/rpi-qtauto/local.conf.sample
@@ -5,3 +5,8 @@ MACHINE = "raspberrypi3"
 RPI_USE_U_BOOT = "1"
 
 LICENSE_FLAGS_WHITELIST = "commercial_faad2"
+
+
+# Improves build time a lot
+# DISTRO_FEATURES_remove = "webengine"
+

--- a/layers/b2qt/recipes-core/images/core-image-pelux-qtauto-neptune-dev.bb
+++ b/layers/b2qt/recipes-core/images/core-image-pelux-qtauto-neptune-dev.bb
@@ -15,4 +15,6 @@ IMAGE_INSTALL += "\
 	openssh-sftp-server \
 	packagegroup-bistro-debug-utils \
 	vim \
+    qtdeclarative-tools \
+    qtwayland-examples \
 "

--- a/layers/b2qt/recipes-qt/packagegroups/packagegroup-b2qt-embedded-qt5-toolchain-target.bbappend
+++ b/layers/b2qt/recipes-qt/packagegroups/packagegroup-b2qt-embedded-qt5-toolchain-target.bbappend
@@ -1,0 +1,48 @@
+# This is a workaround for b2qt since it doesnt officially support rocko.
+# They use @contains_regex which we cannot use. We sould try to get rid
+# of that hack ASAP since we completly overwrite the RDEPENDS for the
+# package group instead of extending. 
+
+RDEPENDS_${PN} = " \
+    ${MACHINE_EXTRA_INSTALL_SDK} \
+    packagegroup-core-standalone-sdk-target \
+    'gcc-sanitizers' \
+    \
+    qt3d-dev \
+    qt3d-runtime-dev \
+    qtbase-dev \
+    qtbase-staticdev \
+    qtbase-doc \
+    qtcanvas3d-dev \
+    qtcharts-dev \
+    qtconnectivity-dev \
+    qtdatavis3d-dev \
+    qtdeclarative-dev \
+    qtdeclarative-staticdev \
+    qtgamepad-dev \
+    qtdeviceutilities-dev \
+    qtgraphicaleffects-dev \
+    qtimageformats-dev \
+    qtlocation-dev \
+    qtmultimedia-dev \
+    qtnetworkauth-dev \
+    qtotaupdate-dev \
+    qtquickcontrols-dev \
+    qtquickcontrols2-dev \
+    qtquicktimeline-dev \
+    qtremoteobjects-dev \
+    qtscxml-dev \
+    qtsensors-dev \
+    qtserialbus-dev \
+    qtserialport-dev \
+    qtsvg-dev \
+    qttools-dev \
+    qttools-staticdev \
+    qtvirtualkeyboard-dev \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'qtwayland-dev', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'webengine', 'qtwebengine-dev qtwebview-dev', '', d)} \
+    qtwebsockets-dev \
+    qtwebchannel-dev \
+    qtxmlpatterns-dev \
+    "
+

--- a/layers/b2qt/recipes-qt/qt5/qtgamepad_%.bbappend
+++ b/layers/b2qt/recipes-qt/qt5/qtgamepad_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG[sdl2] = "-no-feature-sdl2"

--- a/layers/b2qt/recipes-qt/qt5/qtwayland_%.bbappend
+++ b/layers/b2qt/recipes-qt/qt5/qtwayland_%.bbappend
@@ -1,4 +1,5 @@
 #
 # Make sure we build with support for the broadcom driver if building for rpi
 #
+PACKAGECONFIG_append = " examples "
 PACKAGECONFIG_append_rpi = " wayland-brcm "

--- a/recipes-temporary-patches/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/recipes-temporary-patches/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -3,6 +3,10 @@
 # we disable introspection.
 EXTRA_OECONF_aarch64 += "--disable-introspection"
 
+# We overwrite packageconfig since b2qt provides configure options which are
+# not compatible with our version of gstreamer
+PACKAGECONFIG[qt5] = ''
+
 # Wayland support is broken, so remove this until it is fixed upstream. Fixes:
 # | make[3]: *** No rule to make target 'viewporter-protocol.c', needed by 'all'.  Stop.
 PACKAGECONFIG_remove_aarch64 = "wayland"


### PR DESCRIPTION
This patch is required to meta-boot2qt to QtAS-5.12.1 and meta-qt5 to 5.12.
* higher priority to pelux since b2qt bbappends need to be patched
* enabling of rocko for b2qt
* adding examples for wayland to make debugging easier in neptune-dev image
* Fixes and workarounds to build gstreamer and packagegroup-b2qt-embedded-qt5-toolchain-target