### PR TITLE
pelux.conf: set DISTRO_VERSION to master

### DIFF
--- a/conf/distro/pelux.conf
+++ b/conf/distro/pelux.conf
@@ -1,6 +1,6 @@
 #
 #   Copyright (C) 2017 Pelagicore AB
-#   Copyright (C) 2018 Luxoft Sweden AB
+#   Copyright (C) 2018-2019 Luxoft Sweden AB
 #   SPDX-License-Identifier: MIT
 #
 
@@ -9,7 +9,7 @@ require conf/distro/poky.conf
 MAINTAINER = "Gordan Markuš <gordan.markus@pelagicore.com>"
 DISTRO = "pelux"
 DISTRO_NAME = "PELUX"
-DISTRO_VERSION = "3.0"
+DISTRO_VERSION = "master"
 TARGET_VENDOR = "-pelux"
 
 # Add distro features


### PR DESCRIPTION
Changed DISTRO_VERSION to "master" to make it clear a running image
is not a stable release, but a development one.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>