### PR TITLE
core-image-pelux: remove duplicate swupdate installs

### DIFF
--- a/classes/core-image-pelux.bbclass
+++ b/classes/core-image-pelux.bbclass
@@ -1,6 +1,6 @@
 #
 #   Copyright (C) 2017 Pelagicore AB
-#   Copyright (C) 2018 Luxoft Sweden AB
+#   Copyright (C) 2018-2019 Luxoft Sweden AB
 #   SPDX-License-Identifier: MIT
 #
 
@@ -43,17 +43,12 @@ IMAGE_INSTALL_append = "\
 "
 
 # OTA mechanism
-IMAGE_INSTALL_append_rpi = "\
-    swupdate \
-"
-
-IMAGE_INSTALL_append_intel-corei7-64 = "\
+IMAGE_INSTALL_append = "\
     swupdate \
 "
 
 IMAGE_INSTALL_append_arp = "\
     arp-driver \
-    swupdate \
 "
 
 TOOLCHAIN_HOST_TASK += "nativesdk-cmake"


### PR DESCRIPTION
Since swupdate package is installed on all the supported hardware
platforms, it makes no sense to separately append it to IMAGE_INSTALL
for every target.

Use IMAGE_INSTALL_append instead to install package on all the targets
by default and make code cleaner.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>