### PR TITLE
linux-raspberrypi: enable cgroup memory

### DIFF
--- a/meta-rpi-extras/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/meta-rpi-extras/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -1,0 +1,1 @@
+CMDLINE_append = "cgroup_enable=memory"


### PR DESCRIPTION
Qt Application Manager parses /sys/fs/cgroup/memory/memory.stat to
obtain system memory usage information, which is later reported by
the diagnostics app of Neptune 3 UI.

Enable cgroup memory by adding "cgroup_enable=memory" to the command
line, so the app functions on Raspberry Pi.

Relevant information/discussion on using cgroup memory on RPi 3:
https://www.raspberrypi.org/forums/viewtopic.php?t=203128

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>