### PR TITLE
huspell-dicts: add Czech, US English and German dicts

### DIFF
--- a/recipes-support/hunspell/hunspell-dicts_%.bbappend
+++ b/recipes-support/hunspell/hunspell-dicts_%.bbappend
@@ -1,0 +1,12 @@
+do_install_append() {
+    install -m 0755 -d ${D}${datadir}/hunspell
+ 
+    install -m 0755 ${S}/cs_CZ/cs_CZ.dic ${D}${datadir}/hunspell
+    install -m 0755 ${S}/cs_CZ/cs_CZ.aff ${D}${datadir}/hunspell
+
+    install -m 0755 ${S}/de/de_DE_frami.dic ${D}${datadir}/hunspell
+    install -m 0755 ${S}/de/de_DE_frami.aff ${D}${datadir}/hunspell
+
+    install -m 0755 ${S}/en/en_US.dic ${D}${datadir}/hunspell
+    install -m 0755 ${S}/en/en_US.aff ${D}${datadir}/hunspell
+}


### PR DESCRIPTION
Added American English and German dictionaries, so they can be used by
the Qt Virtual Keyboard to perform autocomplete.

With this we cover all the Western languages supported by Neptune 3 UI.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>