### PR TITLE
systemd: remove network configuration

### DIFF
--- a/recipes-core/systemd/systemd/10-pelux-ethernet.network
+++ b/recipes-core/systemd/systemd/10-pelux-ethernet.network
@@ -1,6 +1,0 @@
-[Match]
-Name=en*
-Name=eth*
-
-[Network]
-DHCP=yes

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,16 +1,5 @@
-
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
-
-# This sets up a default ethernet on DHCP
-SRC_URI += "file://10-pelux-ethernet.network"
-
-# We also make sure resolv.conf is using systemd-resolved
 do_install_append() {
-    install -m 0644 ${WORKDIR}/10-pelux-ethernet.network ${D}${sysconfdir}/systemd/network/10-pelux-ethernet.network
-    if [ ! -z "${STATIC_IP_ADDRESS}" ]; then
-    	echo "[Address]" >> ${D}${sysconfdir}/systemd/network/10-pelux-ethernet.network
-    	echo "Address=${STATIC_IP_ADDRESS}/24" >> ${D}${sysconfdir}/systemd/network/10-pelux-ethernet.network
-    fi
+    # Make sure resolv.conf is using systemd-resolved
     ln -s /run/systemd/resolve/resolv.conf ${D}${sysconfdir}/resolv.conf
 
     # Create mutiple consoles


### PR DESCRIPTION
PELUX uses connman as a network manager. Having this configuration in
place was resulting in system using two network management services at
the same time and obtaining 2 IP addresses from DHCP.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>