### PR TITLE
core-image-pelux: remove obsolete cmake sdk fix

### DIFF
--- a/classes/core-image-pelux.bbclass
+++ b/classes/core-image-pelux.bbclass
@@ -53,11 +53,6 @@ IMAGE_INSTALL_append_arp = "\
 
 TOOLCHAIN_HOST_TASK += "nativesdk-cmake"
 
-# Add "/usr/lib/cmake" to the PATH variable so that CMake can find the *Config.cmake" when FIND_PACKAGE() is called from a CMake makefile
-toolchain_create_sdk_env_script_append() {
-	echo 'export PATH=$PATH:$SDKTARGETSYSROOT/usr/lib/cmake' >> $script
-}
-
 IMAGE_ROOTFS_SIZE ?= "1000000"
 IMAGE_FSTYPES ?= "ext3 sdcard"
 


### PR DESCRIPTION
The issue appears to be fixed in the mainstream.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>