### PR TITLE
local.conf: set PREFERRED_PROVIDER for u-boot-fw-utils

### DIFF
--- a/conf/variant/rpi-qtauto/local.conf.sample
+++ b/conf/variant/rpi-qtauto/local.conf.sample
@@ -5,3 +5,5 @@ MACHINE = "raspberrypi3"
 RPI_USE_U_BOOT = "1"
 
 LICENSE_FLAGS_WHITELIST = "commercial_faad2"
+
+PREFERRED_PROVIDER_u-boot-fw-utils = "u-boot-fw-utils"

--- a/conf/variant/rpi/local.conf.sample
+++ b/conf/variant/rpi/local.conf.sample
@@ -5,3 +5,5 @@ MACHINE = "raspberrypi3"
 RPI_USE_U_BOOT = "1"
 
 LICENSE_FLAGS_WHITELIST = "commercial_faad2"
+
+PREFERRED_PROVIDER_u-boot-fw-utils = "u-boot-fw-utils"


### PR DESCRIPTION
Fixes the following warning:
NOTE: Multiple providers are available for u-boot-fw-utils...

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>