### PR TITLE
linux-intel: enable card reader for Intel NUC

### DIFF
--- a/meta-intel-extras/recipes-kernel/linux/linux-intel_%.bbappend
+++ b/meta-intel-extras/recipes-kernel/linux/linux-intel_%.bbappend
@@ -1,9 +1,11 @@
 #
 #   Copyright (C) 2016 Pelagicore AB
-#   Copyright (C) 2018 Luxoft Sweden AB
+#   Copyright (C) 2018-2019 Luxoft Sweden AB
 #
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+KERNEL_FEATURES_append = " features/mmc/mmc-realtek.scc"
 
 # Additional config fragments
 SRC_URI += " \


### PR DESCRIPTION
Enabled Realtek PCI-Express card reader used by Intel NUC.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>