### PR TITLE
neptune.service: Workaround for webengine

### DIFF
--- a/layers/b2qt/recipes-qt/automotive/neptune3-ui/neptune.service
+++ b/layers/b2qt/recipes-qt/automotive/neptune3-ui/neptune.service
@@ -12,6 +12,7 @@ Environment=LC_ALL=en_US
 Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/root/dbus/user_bus_socket
 Environment=QT_IM_MODULE=qtvirtualkeyboard
 Environment=XDG_RUNTIME_DIR=/tmp
+Environment=QTWEBENGINE_CHROMIUM_FLAGS="--no-sandbox --single-process"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Webapps such as youtube are failing on both NUC and RPI.
This environment line will be a workaround fix to both.

Signed-off-by: Fisnik Hajredini <fhajredini@luxoft.com>