### PR TITLE
core-image-pelux: remove swupdate on qemu

### DIFF
--- a/classes/core-image-pelux.bbclass
+++ b/classes/core-image-pelux.bbclass
@@ -47,6 +47,11 @@ IMAGE_INSTALL_append = "\
     swupdate \
 "
 
+# We do not support swupdate on qemu
+IMAGE_INSTALL_remove_qemux86-64 = "\
+    swupdate \
+"
+
 IMAGE_INSTALL_append_arp = "\
     arp-driver \
 "


### PR DESCRIPTION
We do not support swupdate for qemu, therefore the swupdate service
always fails in qemu and causes smoketests to fail.

Signed-off-by: Fisnik Hajredini <fhajredini@luxoft.com>