### PR TITLE
qtivi-mopidy-plugin: add recipe

### DIFF
--- a/classes/core-image-pelux-qtauto.bbclass
+++ b/classes/core-image-pelux-qtauto.bbclass
@@ -1,5 +1,6 @@
 #
 #   Copyright (C) 2017 Pelagicore AB
+#   Copyright (C) 2019 Luxoft Sweden AB
 #   SPDX-License-Identifier: MIT
 #
 
@@ -11,6 +12,7 @@ inherit core-image-pelux
 QTAUTO_COMPONENTS = " \
     qtapplicationmanager \
     qtivi \
+    qtivi-mopidy-plugin \
     qtvirtualkeyboard \
 "
 

--- a/recipes-multimedia/qtivi-mopidy-plugin/qtivi-mopidy-plugin_git.bb
+++ b/recipes-multimedia/qtivi-mopidy-plugin/qtivi-mopidy-plugin_git.bb
@@ -1,0 +1,22 @@
+SUMMARY = "Qt IVI Mopidy media playback plugin"
+HOMEPAGE = "https://github.com/Pelagicore/qtivi-qtivi-plugin"
+SECTION = "libs/multimedia"
+LICENSE = "LGPL-3.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3000208d539ec061b899bce1d9ce9404"
+
+DEPENDS = "qtbase qtwebsockets qtivi"
+RDEPENDS_${PN} = "qtivi"
+
+SRC_URI = "git://github.com/Pelagicore/qtivi-mopidy-plugin.git;protocol=https"
+SRCREV = "dd1621e8f368af91bceb64fd502679e8e507fa2f"
+
+S = "${WORKDIR}/git"
+
+inherit qmake5
+
+do_install() {
+    install -m 0755 -d ${D}${libdir}/plugins/qtivi/
+    install -m 0644 ${WORKDIR}/build/libmedia_mopidy.so ${D}${libdir}/plugins/qtivi/
+}
+
+FILES_${PN} += "${libdir}/plugins/qtivi/"


### PR DESCRIPTION
This recipe builds and installs Mopidy media backend plugin for Qt IVI.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>