### PR TITLE
mopidy: deploy Music directory

### DIFF
--- a/recipes-multimedia/mopidy/mopidy_2.2.2.bb
+++ b/recipes-multimedia/mopidy/mopidy_2.2.2.bb
@@ -16,6 +16,7 @@ PYPI_PACKAGE = "Mopidy"
 inherit pypi setuptools systemd
 
 do_install_append() {
+    install -d ${D}/${ROOT_HOME}/Music
     install -d ${D}/${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/mopidy.service ${D}/${systemd_system_unitdir}
 }
@@ -38,5 +39,9 @@ RRECOMMENDS_${PN} = "\
     pulseaudio-module-native-protocol-tcp \
     "
 
-FILES_${PN} += "${systemd_system_unitdir}/mopidy.service"
+FILES_${PN} += " \
+    ${ROOT_HOME}/Music \
+    ${systemd_system_unitdir}/mopidy.service \
+    "
+
 SYSTEMD_SERVICE_${PN} = "mopidy.service"


### PR DESCRIPTION
Mopidy is configured to look for audio files in /home/root/Music folder,
which is not present on the filesystem.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>