### PR TITLE
grub-efi: fix file permissions

### DIFF
--- a/meta-intel-extras/recipes-support/grub/grub-efi_%.bbappend
+++ b/meta-intel-extras/recipes-support/grub/grub-efi_%.bbappend
@@ -13,9 +13,9 @@ do_install_append() {
     install -d ${D}${datadir}
     install -d ${D}${systemd_system_unitdir}
 
-    install -m 0755 ${WORKDIR}/grubenv ${D}${datadir}
+    install -m 0644 ${WORKDIR}/grubenv ${D}${datadir}
     install -m 0755 ${WORKDIR}/grubenv-copy.sh ${D}${bindir}
-    install -m 0755 ${WORKDIR}/grubenv-copy.service ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/grubenv-copy.service ${D}${systemd_system_unitdir}
 }
 
 FILES_${PN} += " \


### PR DESCRIPTION
All service files should have 644 permissions.

Permissions of grubenv on Ubuntu is also 644, so do the same on PELUX.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>