### PR TITLE
Acrn

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -23,4 +23,4 @@ BBFILES += "${@' '.join('${LAYERDIR}/layers/%s/recipes*/*/*.bbappend' % layer \
 BBFILES += "${@' '.join('${LAYERDIR}/layers/%s/recipes*/*/*.bb' % layer \
                for layer in BBFILE_COLLECTIONS.split())}"
 
-LAYERSERIES_COMPAT_pelux-layer = "sumo thud"
+LAYERSERIES_COMPAT_pelux-layer = "sumo thud warrior"

--- a/conf/variant/arp/multiconfig/sos.conf
+++ b/conf/variant/arp/multiconfig/sos.conf
@@ -1,0 +1,17 @@
+TMPDIR="${TOPDIR}/tmpsos"
+MACHINE = "intel-corei7-64"
+
+EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
+LICENSE_FLAGS_WHITELIST = "commercial_faad2"
+
+# ACRN specific
+PREFERRED_PROVIDER_virtual/kernel = "linux-acrn"
+KERNEL_DEFCONFIG = "kernel_config_uefi_sos"
+
+EFI_PROVIDER = "systemd-boot"
+
+WKS_FILE = "acrn-sos.wks.in"
+
+IMAGE_INSTALL_append_pn-core-image-pelux-sos = " android-x86-vm "
+
+IMAGE_FSTYPES = "wic"

--- a/conf/variant/arp/multiconfig/uos.conf
+++ b/conf/variant/arp/multiconfig/uos.conf
@@ -1,0 +1,18 @@
+#require conf/variant/common/local.conf
+
+TMPDIR="${TOPDIR}/tmpuos"
+MACHINE = "intel-corei7-64"
+
+EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
+LICENSE_FLAGS_WHITELIST += "commercial"
+
+IMAGE_INSTALL_remove = "swupdate"
+
+IMAGE_FEATURES_append = " ssh-server-openssh"
+
+PREFERRED_PROVIDER_virtual/kernel = "linux-acrn-uos"
+KERNEL_DEFCONFIG ??= "kernel_config_uos_arp"
+
+IMAGE_FSTYPES = "wic"
+
+LICENSE_FLAGS_WHITELIST = "commercial_faad2"

--- a/layers/acrn-layer/recipes-core/images/core-image-pelux-sos.bb
+++ b/layers/acrn-layer/recipes-core/images/core-image-pelux-sos.bb
@@ -1,0 +1,17 @@
+# Copyright (C) Luxoft Sweden AB
+# Released under the MIT license (see LICENSE for the terms)
+
+inherit core-image-pelux
+inherit acrn-service-os
+
+IMAGE_INSTALL_append = " \
+    efibootmgr \
+    pelux-vm \
+"
+
+IMAGE_FEATURES_append = " \
+    ssh-server-openssh \
+"
+
+IMAGE_INSTALL_remove += "swupdate"
+IMAGE_INSTALL_remove += "arp-driver"

--- a/layers/acrn-layer/recipes-vms/acrn-vm-init/acrn-vm-init/acrn-vm-init.service
+++ b/layers/acrn-layer/recipes-vms/acrn-vm-init/acrn-vm-init/acrn-vm-init.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=ACRN Initialization procedure
+
+[Service]
+Type=oneshot
+ExecStart=/usr/share/acrn/scripts/acrn-vm-init.sh
+
+[Install]
+WantedBy=multi-user-target

--- a/layers/acrn-layer/recipes-vms/acrn-vm-init/acrn-vm-init/acrn-vm-init.sh
+++ b/layers/acrn-layer/recipes-vms/acrn-vm-init/acrn-vm-init/acrn-vm-init.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# offline SOS CPUs except BSP before launch UOS
+for i in `ls -d /sys/devices/system/cpu/cpu[1-99]`; do
+        online=`cat $i/online`
+        idx=`echo $i | tr -cd "[1-99]"`
+        echo cpu$idx online=$online
+        if [ "$online" = "1" ]; then
+                echo 0 > $i/online
+		# during boot time, cpu hotplug may be disabled by pci_device_probe during a pci module insmod
+		while [ "$online" = "1" ]; do
+			sleep 1
+			echo 0 > $i/online
+			online=`cat $i/online`
+		done
+                echo $idx > /sys/class/vhm/acrn_vhm/offline_cpu
+        fi
+done

--- a/layers/acrn-layer/recipes-vms/acrn-vm-init/acrn-vm-init_1.0.0.bb
+++ b/layers/acrn-layer/recipes-vms/acrn-vm-init/acrn-vm-init_1.0.0.bb
@@ -1,0 +1,28 @@
+# Copyright (C) 2019 Luxoft Sweden AB
+# Released under the MIT license (see LICENSE for the terms)
+
+DESCRIPTION = "Systemd targets for starting ACRN VMs"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=dd98d01d471fac8d8dbdd975229dba03"
+
+inherit systemd
+
+S = "${WORKDIR}"
+
+SRC_URI = "                \
+    file://LICENSE         \
+    file://acrn-vm-init.service \
+    file://acrn-vm-init.sh \
+    "
+
+FILES_${PN} = "                                    \
+    ${datadir}/acrn/scripts/acrn-vm-init.sh        \
+    ${systemd_system_unitdir}/acrn-init-vm.service \
+    "
+
+SYSTEMD_SERVICE_${PN} = "acrn-vm-init.service"
+
+do_install_append() {
+    install -D -m 0755 ${S}/acrn-vm-init.sh ${D}${datadir}/acrn/scripts/acrn-vm-init.sh
+    install -D -m 0644 ${S}/acrn-vm-init.service ${D}${systemd_system_unitdir}/acrn-vm-init.service
+}

--- a/layers/acrn-layer/recipes-vms/android-x86/android-x86-vm/.gitignore
+++ b/layers/acrn-layer/recipes-vms/android-x86/android-x86-vm/.gitignore
@@ -1,0 +1,1 @@
+android-x86-uninstalled.iso

--- a/layers/acrn-layer/recipes-vms/android-x86/android-x86-vm/LICENSE
+++ b/layers/acrn-layer/recipes-vms/android-x86/android-x86-vm/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/layers/acrn-layer/recipes-vms/android-x86/android-x86-vm/android-x86-vm.service
+++ b/layers/acrn-layer/recipes-vms/android-x86/android-x86-vm/android-x86-vm.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Start Android-x86 UOS
+After=acrnprobe.service
+After=weston.service
+After=systemd-resolved.service
+
+ConditionPathExists=/sys/kernel/gvt
+ConditionPathExists=/dev/acrn_vhm
+
+[Service]
+Type=simple
+RemainAfterExit=false
+ExecStart=/bin/sh /usr/share/acrn/scripts/launch_android_x86.sh
+
+[Install]
+WantedBy=acrn-vm2.target

--- a/layers/acrn-layer/recipes-vms/android-x86/android-x86-vm/launch_android_x86.sh
+++ b/layers/acrn-layer/recipes-vms/android-x86/android-x86-vm/launch_android_x86.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+function launch_linux_uos()
+{
+vm_name=$1
+
+# create a unique tap device for each VM
+tap="tap1"
+tap_exist=$(ip a | grep acrn_"$tap" | awk '{print $1}')
+if [ "$tap_exist"x != "x" ]; then
+  echo "tap device existed, reuse acrn_$tap"
+else
+  ip tuntap add dev acrn_$tap mode tap
+fi
+
+# if acrn-br0 exists, add VM's unique tap device under it
+br_exist=$(ip a | grep acrn-br0 | awk '{print $1}')
+if [ "$br_exist"x != "x" -a "$tap_exist"x = "x" ]; then
+  echo "acrn-br0 bridge aleady exists, adding new tap device to it..."
+  ip link set acrn_"$tap" master acrn-br0
+  ip link set dev acrn_"$tap" down
+  ip link set dev acrn_"$tap" up
+fi
+
+#check if the vm is running or not
+vm_ps=$(pgrep -a -f acrn-dm)
+result=$(echo $vm_ps | grep "${vm_name}")
+if [[ "$result" != "" ]]; then
+  echo "$vm_name is running, can't create twice!"
+  exit 1
+fi
+
+#for memsize setting
+mem_size=3072M
+
+acrn-dm -A -m $mem_size -c $2 -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
+  -s 2,pci-gvt -G "$3" \
+  -s 5,virtio-console,@pty:pty_port \
+  -s 6,virtio-hyper_dmabuf \
+  -r /usr/share/acrn/images/android-x86/initrd.img \
+  -s 8,virtio-blk,/usr/share/acrn/images/android-x86/android.img \
+  -s 4,virtio-net,$tap \
+  -s 7,xhci,1-7 \
+  -k /usr/share/acrn/images/android-x86/kernel \
+  -B "console=tty0 console=hvc0 \
+  console=ttyS0 root=/dev/ram0 no_timer_check log_buf_len=16M loglevel=6 \
+  consoleblank=0 tsc=reliable i915.avail_planes_per_pipe=$4 vga=current modeset=1 \
+  i915.enable_hangcheck=0 i915.nuclear_pageflip=1 i915.enable_guc_loading=0 \
+  i915.enable_guc_submission=0 i915.enable_guc=0 security=selinux androidboot.selinux=permissive androidboot.hardware=acrn_android_x86_64 \
+  SRC=android-8.1-r1 DATA= " $vm_name
+}
+
+ipu_passthrough=0
+# Check the device file of /dev/vbs_ipu to determine the IPU mode
+if [ ! -e "/dev/vbs_ipu" ]; then
+ipu_passthrough=1
+fi
+
+cse_passthrough=0
+hbm_ver=`cat /sys/class/mei/mei0/hbm_ver`
+major_ver=`echo $hbm_ver | cut -d '.' -f1`
+minor_ver=`echo $hbm_ver | cut -d '.' -f2`
+if [[ "$major_ver" -lt "2" ]] || \
+   [[ "$major_ver" == "2" && "$minor_ver" -lt "2" ]]; then
+    cse_passthrough=1
+fi
+
+# offline SOS CPUs except BSP before launch UOS
+for i in `ls -d /sys/devices/system/cpu/cpu[1-99]`; do
+        online=`cat $i/online`
+        idx=`echo $i | tr -cd "[1-99]"`
+        echo cpu$idx online=$online
+        if [ "$online" = "1" ]; then
+                echo 0 > $i/online
+		# during boot time, cpu hotplug may be disabled by pci_device_probe during a pci module insmod
+		while [ "$online" = "1" ]; do
+			sleep 1
+			echo 0 > $i/online
+			online=`cat $i/online`
+		done
+                echo $idx > /sys/class/vhm/acrn_vhm/offline_cpu
+        fi
+done
+
+launch_linux_uos "android-x86" 2 "64 448 4" 0x090000

--- a/layers/acrn-layer/recipes-vms/android-x86/android-x86-vm_1.0.0.bb
+++ b/layers/acrn-layer/recipes-vms/android-x86/android-x86-vm_1.0.0.bb
@@ -1,0 +1,76 @@
+# Copyright (C) 2019 Luxoft Sweden AB
+# Released under the MIT license (see LICENSE for the terms)
+
+DESCRIPTION = "Installs an android-x86 VM"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
+
+DEPENDS = "squashfs-tools-native parted-native xorriso-native e2fsprogs-native"
+RDEPENDS_${PN} = "acrn-vm-targets acrn-vm-init bash"
+
+inherit systemd
+
+S = "${WORKDIR}"
+
+SRC_URI = "                 \
+    file://LICENSE          \
+    file://launch_android_x86.sh  \
+    file://android-x86-vm.service \
+    file://android-x86-uninstalled.iso \
+    "
+
+FILES_${PN} = "               \
+    ${datadir}/acrn/scripts/* \
+    ${systemd_system_unitdir}/*          \
+    ${datadir}/acrn/images/android-x86/android.img \
+    ${datadir}/acrn/images/android-x86/initrd.img \
+    ${datadir}/acrn/images/android-x86/kernel \
+    "
+
+SYSTEMD_SERVICE_${PN} = "android-x86-vm.service"
+
+do_compile() {
+
+    cd ${WORKDIR}
+
+    for file_to_extract in system.sfs ramdisk.img initrd.img kernel
+    do
+        xorriso -osirrox on -indev android-x86-uninstalled.iso -extract $file_to_extract ${WORKDIR}/$file_to_extract
+    done
+
+    # Allocating disk image...
+    SIZE_M=3500
+    dd if=/dev/zero of=android.img bs=1M count=0 seek=$SIZE_M
+
+    # Partitioning...
+    parted android.img mklabel msdos --script
+    # Creating ext4 FS...
+    parted -a opt android.img mkpart primary ext4 0% 100% --script
+
+    #Put the files (system.img, ramdisk.img) into the partition created.
+    echo Repacking...
+
+    IMG_MNT_DIR="${WORKDIR}/img_mnt"
+    unsquashfs -d ${IMG_MNT_DIR} system.sfs
+    cp ramdisk.img ${IMG_MNT_DIR}/ramdisk.img
+
+    mkdir -p ${IMG_MNT_DIR}/data
+    chmod 755 ${IMG_MNT_DIR}/data
+
+    #Offset is the sector size * begining of the partition
+    mkfs.ext4 -F -Eoffset=1048576 -d ${IMG_MNT_DIR} android.img
+
+    rm -R ${IMG_MNT_DIR}
+}
+
+do_install_append() {
+    install -D -m 0755 ${S}/launch_android_x86.sh ${D}${datadir}/acrn/scripts/launch_android_x86.sh
+    install -D -m 0755 ${S}/android-x86-vm.service ${D}${systemd_system_unitdir}/android-x86-vm.service
+
+    install -D -m 0644 ${WORKDIR}/initrd.img \
+                       ${D}${datadir}/acrn/images/android-x86/initrd.img
+    install -D -m 0644 ${WORKDIR}/android.img \
+                       ${D}${datadir}/acrn/images/android-x86/android.img
+    install -D -m 0644 ${WORKDIR}/kernel \
+                       ${D}${datadir}/acrn/images/android-x86/kernel
+}

--- a/layers/acrn-layer/recipes-vms/pelux/pelux-vm/LICENSE
+++ b/layers/acrn-layer/recipes-vms/pelux/pelux-vm/LICENSE
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy 
+of this software and associated documentation files (the "Software"), to deal 
+in the Software without restriction, including without limitation the rights 
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+copies of the Software, and to permit persons to whom the Software is 
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in 
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
+THE SOFTWARE.

--- a/layers/acrn-layer/recipes-vms/pelux/pelux-vm/launch_pelux.sh
+++ b/layers/acrn-layer/recipes-vms/pelux/pelux-vm/launch_pelux.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+function launch_linux_uos()
+{
+
+# create a unique tap device for each VM
+tap="tap0"
+tap_exist=$(ip a | grep acrn_"$tap" | awk '{print $1}')
+if [ "$tap_exist"x != "x" ]; then
+  echo "tap device existed, reuse acrn_$tap"
+else
+  ip tuntap add dev acrn_$tap mode tap
+fi
+
+# if acrn-br0 exists, add VM's unique tap device under it
+br_exist=$(ip a | grep acrn-br0 | awk '{print $1}')
+if [ "$br_exist"x != "x" -a "$tap_exist"x = "x" ]; then
+  echo "acrn-br0 bridge aleady exists, adding new tap device to it..."
+  ip link set acrn_"$tap" master acrn-br0
+  ip link set dev acrn_"$tap" down
+  ip link set dev acrn_"$tap" up
+fi
+
+
+vm_name=$1
+
+#check if the vm is running or not
+vm_ps=$(pgrep -a -f acrn-dm)
+result=$(echo $vm_ps | grep "${vm_name}")
+if [[ "$result" != "" ]]; then
+  echo "$vm_name is running, can't create twice!"
+  exit 1
+fi
+
+#for memsize setting
+mem_size=2048M
+
+acrn-dm -A -m $mem_size -c $2 -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
+  -s 2,pci-gvt -G "$3" \
+  -s 5,virtio-console,@pty:pty_port \
+  -s 6,virtio-hyper_dmabuf \
+  -s 3,virtio-blk,/usr/share/acrn/images/linux/pelux.img \
+  -s 4,virtio-net,$tap \
+  -s 7,xhci,1-3 \
+  -s 25,passthru,1/0/0 \
+  -k /usr/share/acrn/images/linux/bzImage \
+  -B "root=/dev/vda3 rw rootwait maxcpus=$2 nohpet console=tty0 console=hvc0 \
+  console=ttyS0 no_timer_check log_buf_len=16M loglevel=2 \
+  consoleblank=0 tsc=reliable i915.avail_planes_per_pipe=$4 \
+  i915.enable_hangcheck=0 i915.nuclear_pageflip=1 i915.enable_guc_loading=0 \
+  i915.enable_guc_submission=0 i915.enable_guc=0" $vm_name
+}
+
+ipu_passthrough=0
+# Check the device file of /dev/vbs_ipu to determine the IPU mode
+if [ ! -e "/dev/vbs_ipu" ]; then
+ipu_passthrough=1
+fi
+
+cse_passthrough=0
+hbm_ver=`cat /sys/class/mei/mei0/hbm_ver`
+major_ver=`echo $hbm_ver | cut -d '.' -f1`
+minor_ver=`echo $hbm_ver | cut -d '.' -f2`
+if [[ "$major_ver" -lt "2" ]] || \
+   [[ "$major_ver" == "2" && "$minor_ver" -lt "2" ]]; then
+    cse_passthrough=1
+fi
+
+# offline SOS CPUs except BSP before launch UOS
+for i in `ls -d /sys/devices/system/cpu/cpu[1-99]`; do
+        online=`cat $i/online`
+        idx=`echo $i | tr -cd "[1-99]"`
+        echo cpu$idx online=$online
+        if [ "$online" = "1" ]; then
+                echo 0 > $i/online
+		# during boot time, cpu hotplug may be disabled by pci_device_probe during a pci module insmod
+		while [ "$online" = "1" ]; do
+			sleep 1
+			echo 0 > $i/online
+			online=`cat $i/online`
+		done
+                echo $idx > /sys/class/vhm/acrn_vhm/offline_cpu
+        fi
+done
+
+launch_linux_uos "core-image-pelux-qtauto-neptune-uos" 1 "64 448 4" 0x000F0F

--- a/layers/acrn-layer/recipes-vms/pelux/pelux-vm/pelux-vm.service
+++ b/layers/acrn-layer/recipes-vms/pelux/pelux-vm/pelux-vm.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Start PELUX UOS
+After=acrnprobe.service
+After=weston.service
+After=systemd-resolved.service
+Before=acrn-vm2.target
+
+ConditionPathExists=/sys/kernel/gvt
+ConditionPathExists=/dev/acrn_vhm
+
+[Service]
+Type=simple
+RemainAfterExit=false
+ExecStart=/bin/sh /usr/share/acrn/scripts/launch_pelux.sh
+
+[Install]
+WantedBy=acrn-vm1.target

--- a/layers/acrn-layer/recipes-vms/pelux/pelux-vm_1.0.0.bb
+++ b/layers/acrn-layer/recipes-vms/pelux/pelux-vm_1.0.0.bb
@@ -1,0 +1,42 @@
+# Copyright (C) 2019 Luxoft Sweden AB
+# Released under the MIT license (see LICENSE for the terms)
+
+DESCRIPTION = "Script that starts a PELUX-VM"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3da9cfbcb788c80a0384361b4de20420"
+
+RDEPENDS_${PN} = "acrn-vm-targets acrn-vm-init bash"
+
+inherit systemd
+
+S = "${WORKDIR}"
+
+SRC_URI = "                 \
+    file://LICENSE          \
+    file://launch_pelux.sh  \
+    file://pelux-vm.service \
+    "
+
+FILES_${PN} = "               \
+    ${datadir}/acrn/scripts/* \
+    ${systemd_system_unitdir}/*          \
+    ${datadir}/acrn/images/linux/pelux.img \
+    ${datadir}/acrn/images/linux/bzImage \
+    "
+
+SYSTEMD_SERVICE_${PN} = "pelux-vm.service"
+
+
+PELUX_IMAGE ?= "core-image-pelux-minimal"
+
+do_install[mcdepends] = "multiconfig:sos:uos:${PELUX_IMAGE}:do_image_complete"
+
+do_install_append() {
+    install -D -m 0755 ${S}/launch_pelux.sh ${D}${datadir}/acrn/scripts/launch_pelux.sh
+    install -D -m 0755 ${S}/pelux-vm.service ${D}${systemd_system_unitdir}/pelux-vm.service
+
+    install -D -m 0644 ${TOPDIR}/tmpuos/deploy/images/${MACHINE}/${PELUX_IMAGE}-${MACHINE}.wic \
+                       ${D}${datadir}/acrn/images/linux/pelux.img
+    install -D -m 0644 ${TOPDIR}/tmpuos/deploy/images/${MACHINE}/bzImage \
+                       ${D}${datadir}/acrn/images/linux/bzImage
+}

--- a/layers/acrn-layer/recipes-vms/targets/acrn-vm-targets/acrn-vm1.target
+++ b/layers/acrn-layer/recipes-vms/targets/acrn-vm-targets/acrn-vm1.target
@@ -1,0 +1,9 @@
+[Unit]
+Description=First ACRN VM to start
+After=acrn-vm-init.service
+Requires=acrn-vm-init.service
+Before=acrn-vm2.target
+Wants=acrn-vm2.target
+
+[Install]
+WantedBy=multi-user.target

--- a/layers/acrn-layer/recipes-vms/targets/acrn-vm-targets/acrn-vm2.target
+++ b/layers/acrn-layer/recipes-vms/targets/acrn-vm-targets/acrn-vm2.target
@@ -1,0 +1,9 @@
+[Unit]
+Description=Second ACRN VM to start
+After=acrn-vm-init.service
+Requires=acrn-vm-init.service
+Before=acrn-vm3.target
+Wants=acrn-vm3.target
+
+[Install]
+WantedBy=multi-user.target

--- a/layers/acrn-layer/recipes-vms/targets/acrn-vm-targets/acrn-vm3.target
+++ b/layers/acrn-layer/recipes-vms/targets/acrn-vm-targets/acrn-vm3.target
@@ -1,0 +1,7 @@
+[Unit]
+Description=Third ACRN VM to start
+After=acrn--vm-init.service
+Requires=acrn-vm-init.service
+
+[Install]
+WantedBy=multi-user.target

--- a/layers/acrn-layer/recipes-vms/targets/acrn-vm-targets_1.0.0.bb
+++ b/layers/acrn-layer/recipes-vms/targets/acrn-vm-targets_1.0.0.bb
@@ -1,0 +1,33 @@
+# Copyright (C) 2019 Luxoft Sweden AB
+# Released under the MIT license (see LICENSE for the terms)
+
+DESCRIPTION = "Systemd targets for starting ACRN VMs"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=dd98d01d471fac8d8dbdd975229dba03"
+
+RDEPENDS_${PN} = "acrn-vm-init"
+
+inherit systemd
+
+S = "${WORKDIR}"
+
+SRC_URI = "                \
+    file://LICENSE         \
+    file://acrn-vm1.target \
+    file://acrn-vm2.target \
+    file://acrn-vm3.target \
+    "
+
+FILES_${PN} = "               \
+    ${systemd_system_unitdir}/acrn-vm1.target  \
+    ${systemd_system_unitdir}/acrn-vm2.target  \
+    ${systemd_system_unitdir}/acrn-vm3.target  \
+    "
+
+SYSTEMD_SERVICE_${PN} = "acrn-vm1.target"
+
+do_install_append() {
+    install -D -m 0755 ${S}/acrn-vm1.target ${D}${systemd_system_unitdir}/acrn-vm1.target
+    install -D -m 0755 ${S}/acrn-vm2.target ${D}${systemd_system_unitdir}/acrn-vm2.target
+    install -D -m 0755 ${S}/acrn-vm3.target ${D}${systemd_system_unitdir}/acrn-vm3.target
+}

--- a/meta-intel-extras/conf/layer.conf
+++ b/meta-intel-extras/conf/layer.conf
@@ -13,4 +13,4 @@ BBFILE_PATTERN_pelux-bsp-intel-layer := "^${LAYERDIR}/"
 
 BBFILE_PRIORITY_pelux-bsp-intel-layer = "10"
 
-LAYERSERIES_COMPAT_pelux-bsp-intel-layer = "sumo thud"
+LAYERSERIES_COMPAT_pelux-bsp-intel-layer = "sumo thud warrior"

--- a/meta-rpi-extras/conf/layer.conf
+++ b/meta-rpi-extras/conf/layer.conf
@@ -13,4 +13,4 @@ BBFILE_PATTERN_pelux-bsp-rpi-layer := "^${LAYERDIR}/"
 
 BBFILE_PRIORITY_pelux-bsp-rpi-layer = "10"
 
-LAYERSERIES_COMPAT_pelux-bsp-rpi-layer = "sumo thud"
+LAYERSERIES_COMPAT_pelux-bsp-rpi-layer = "sumo thud warrior"

--- a/scripts/lib/wic/canned-wks/mkefidisk-multiboot.wks
+++ b/scripts/lib/wic/canned-wks/mkefidisk-multiboot.wks
@@ -2,12 +2,12 @@
 # long-description: Creates a partitioned EFI disk image that the user
 # can directly dd to boot media.
 
-part /boot --source bootimg-efi --sourceparams="loader=grub-efi" --ondisk sda --label msdos --active --align 1024
+part /boot --source bootimg-efi --sourceparams="loader=grub-efi" --ondisk sda --label msdos --active --align 1024 --use-uuid
 
-part / --source rootfs --ondisk sda --fstype=ext4 --label platform --align 1024
+part / --source rootfs --ondisk sda --fstype=ext4 --label platformA --align 1024 --use-uuid
 
-part / --source rootfs --ondisk sda --fstype=ext4 --label platform --align 1024
+part / --source rootfs --ondisk sda --fstype=ext4 --label platformB --align 1024 --use-uuid
 
-part swap --ondisk sda --size 44 --label swap1 --fstype=swap
+part swap --ondisk sda --size 44 --label swap1 --fstype=swap --use-uuid
 
 bootloader --configfile cfg --ptable gpt --timeout=5 --append="rootfstype=ext4 console=ttyS0,115200 console=tty0"


### PR DESCRIPTION
This PR adds config and recipes used to create Service-OS and User-OS images using PELUX.

It should be fairly non-intrusive and is tested and verified to work with ARP/Intel. However, there are some things to consider:

* It is based on poky warrior since some things in the setup is broken in thud
* There is a workaround commit (104f668) that is not compliant with swupdate so this needs to be fixed

As this is already tested I am mostly interested in semantics, the notes above and or structure reviews.