### PR TITLE
systemd: enable kmod

### DIFF
--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -11,3 +11,7 @@ do_install_append() {
 
 FILES_${PN} += "/etc/resolv.conf"
 FILES_${PN} += "${sysconfdir}/systemd/system/getty.target.wants"
+
+PACKAGECONFIG += " \
+    kmod \
+"


### PR DESCRIPTION
Enable kmod in systemd which makes systemd include the
systemd-load-modules.service. Without this service systemd will not
automatically load kernel modules at boot.