### PR TITLE
Add device /dev/dri/card0 to device node gateway

### DIFF
--- a/recipes-containers/softwarecontainer/files/io.qt.ApplicationManager.Application.json
+++ b/recipes-containers/softwarecontainer/files/io.qt.ApplicationManager.Application.json
@@ -39,6 +39,9 @@
           "id": "devicenode",
           "config": [
             {
+              "name": "/dev/dri/card0"
+            },
+            {
               "name": "/dev/dri/renderD128"
             },
             {


### PR DESCRIPTION
The device node gateway was only bind mounting /dev/dri/renderD128
render node. This was sufficient for accessing non-previliged GPU
operations by neptune applications. Previously, this seemed sufficient
with the neptune calendar application running inside container. But,
recently it seems that wayland compositer require access to previliged
GPU operations. Primary node /dev/dri/card0 is required to access these
operations, so this device node is bind mounted inside the container.

Signed-off-by: Tariq Ansari <tansari@luxoft.com>