### PR TITLE
Use WAYLAND_DISPLAY env var in neptune & softwarecontainer

### DIFF
--- a/layers/b2qt/recipes-qt/automotive/neptune3-ui/neptune.service
+++ b/layers/b2qt/recipes-qt/automotive/neptune3-ui/neptune.service
@@ -13,6 +13,7 @@ Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/root/dbus/user_bus_sock
 Environment=QT_IM_MODULE=qtvirtualkeyboard
 Environment=XDG_RUNTIME_DIR=/tmp
 Environment=QTWEBENGINE_CHROMIUM_FLAGS="--no-sandbox --single-process"
+Environment=WAYLAND_DISPLAY="qtam-wayland-0"
 
 [Install]
 WantedBy=multi-user.target

--- a/recipes-containers/softwarecontainer/files/softwarecontainer-agent.service
+++ b/recipes-containers/softwarecontainer/files/softwarecontainer-agent.service
@@ -9,6 +9,7 @@ BusName=com.pelagicore.SoftwareContainerAgent
 ExecStart=/usr/bin/softwarecontainer-agent
 Environment=XDG_RUNTIME_DIR=/tmp
 Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/root/dbus/user_bus_socket
+Environment=WAYLAND_DISPLAY="qtam-wayland-0"
 
 [Install]
 WantedBy=basic.target


### PR DESCRIPTION
Wayland socket file name was hardcode in softwarecontainer which
resulted in failure if the wayland socket file name was changed
on the file system. Neptune provides WAYLAND_DISPLAY env variable
to define the name of the WAYLAND socket. Use this variable to
set the socket name in neptune and softwarecontainer.

Signed-off-by: Tariq Ansari <tansari@luxoft.com>