### PR TITLE
Jenkinsfile: script for build abortion moved on top of node assignment

### DIFF
--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -15,22 +15,6 @@ void buildPelux(String variant, String imageName) {
     }
 
     node("Yocto") {
-        // If there is a build for this PR in progress, abort it
-        script {
-            def jobname = env.JOB_NAME
-            def buildnum = env.BUILD_NUMBER.toInteger()
-            def job = Jenkins.instance.getItemByFullName(jobname)
-
-            for (build in job.builds) {
-                if (!build.isBuilding()) {
-                    continue;
-                }
-
-                println("Aborting previous running build #${build.number}...") 
-
-                build.doStop();
-            }
-        }
         dir(peluxDir) {
             checkout scm
         }
@@ -44,6 +28,26 @@ void buildPelux(String variant, String imageName) {
             String peluxPath = "${env.WORKSPACE}/${peluxDir}"
             code.buildWithLayer(variant, imageName, peluxDir, peluxPath)
         }
+    }
+}
+
+// If there is a build for this PR in progress, abort it
+script {
+    def jobname = env.JOB_NAME
+    def buildnum = env.BUILD_NUMBER.toInteger()
+    def job = Jenkins.instance.getItemByFullName(jobname)
+
+    for (build in job.builds) {
+        if (!build.isBuilding()) {
+            continue;
+        }
+        if (buildnum == build.getNumber().toInteger()) { 
+            continue; 
+        }
+
+        println("Aborting previous running build #${build.number}...")
+
+        build.doStop();
     }
 }
 


### PR DESCRIPTION
Script should be moved on top of node assignment as previous build will not be interrupted when all nodes are busy
Signed-off-by: Dmytro Iurchuk <diurchuk@luxoft.com>