### PR TITLE
Use PARTUUID to boot intel and ARP targets

### DIFF
--- a/meta-intel-extras/recipes-core/base-files/base-files/intel-corei7-64/fstab
+++ b/meta-intel-extras/recipes-core/base-files/base-files/intel-corei7-64/fstab
@@ -1,3 +1,3 @@
 /dev/root            /                    auto       defaults              1  1
-/dev/sda1	/boot	vfat	defaults	0	0
-/dev/sda4	swap	swap	defaults	0	0
+PARTUUID=279767e4-75b9-4b6b-92ca-cddbe821e3a6	/boot	vfat	defaults	0	0
+PARTUUID=36e409e3-bec6-4d36-9d93-51f917421531	swap	swap	defaults	0	0

--- a/recipes-extended/images/pelux-image-update/arp/emmcsetup2.lua
+++ b/recipes-extended/images/pelux-image-update/arp/emmcsetup2.lua
@@ -5,11 +5,6 @@ function os.capture(cmd)
 	return s
 end
 
-function file_exists(name)
-	local f=io.open(name,"r")
-	if f~=nil then io.close(f) return true else return false end
-end
-
 function cmdexec(cmd)
 	local ret, s, status = os.execute(cmd)
 	if (status ~= 0) then
@@ -19,109 +14,113 @@ function cmdexec(cmd)
 	return true,""
 end
 
-function preinst()
-	local out
-	local s1
+function get_device_from_boot_device_label(label)
+	local pdev
+	local dev
+
+	pdev = os.capture("lsblk -no PARTLABEL,PKNAME | grep " .. label .. " | awk '{print $2}'")
+
+	dev = os.capture("lsblk -no PARTLABEL,KNAME | grep " .. label .. " | awk '{print $2}'")
+
+	return pdev, dev
+end
+
+function get_update_device_from_boot_device(dev)
+	local part = ""
+	local length = dev:len()-1
+	local num = dev:sub(length, length)
+
+	if ("2" == num) then
+		part = "3"
+	elseif ("3" == num) then
+		part = "2"
+	else
+		return false, "Incorrect Partition number " .. num
+	end
+
+	local updatedev = dev:sub(1, length-1) .. part
+
+	return true, updatedev
+end
+
+function get_update_device_from_boot_device_label(label)
 	local ret
+	local pdev
+	local bootdev
+	local updatedev
 
-	local log = os.tmpname()
+	pdev, bootdev = get_device_from_boot_device_label(label)
 
-	local eMMC = "/dev/sda"
-	ret = file_exists("/dev/sda")
+	ret, updatedev = get_update_device_from_boot_device(bootdev)
 
+	print("Boot Device:", bootdev, "Update Device:", updatedev)
+
+	return ret, updatedev
+end
+
+function preinst()
+	local out = "Pre installed script called"
+	local ret
+	local updatedev
+
+	ret, updatedev = get_update_device_from_boot_device_label("platform1")
 	if (ret == false) then
-		return false, "Cannot find eMMC"
+		return ret, updatedev .. ", Cannot find update device"
 	end
 
-	ret, out = cmdexec("/usr/sbin/sfdisk -d " .. eMMC .. "> /tmp/dumppartitions")
+	ret, out = cmdexec("ln -s /dev/" .. updatedev .. " /dev/updatedev")
 	if (false == ret) then
 		return ret, out
 	end
 
-	-- check if there are two identical partitions
-	-- and create the second one if no available
-	f = io.input("/tmp/dumppartitions")
-	fo = io.output("/tmp/partitions")
-	t = f:read()
-	found = false
-	while (t ~= nil) do
-		j=0
-		j=string.find(t, "/dev/sda3")
-		ret, out = fo:write(t .. "\n")
-		if (ret == nil) then
-			fo:close()
-			f:close()
-			return false, out
-		end
-		if (j == 1) then
-			found=true
-			break
-		end
-		j=string.find(t, "/dev/sda2")
-		if (j == 1) then
-			start, size = string.match(t, "%a+%s*=%s*(%d+), size=%s*(%d+)")
-		end
-		t = f:read()
-	end
-
-	if (found) then
-		f:close()
-		fo:close()
-		return true, out
-	end
-
-	start=start+size
-	partitions = eMMC .. "3 : start=    " .. string.format("%d", start) .. ", size=  " .. size .. ", type=83\n"
-
-	ret, out = fo:write(partitions)
-	fo:close()
-	f:close()
-
-	if (ret == nil) then
-		return ret, out
-	end
-
-	out = os.capture("/usr/sbin/sfdisk --force " .. eMMC .. " < /tmp/partitions")
-
-	-- use partprobe to inform the kernel of the new partitions
-
-	ret, out = cmdexec("/usr/sbin/partprobe " .. eMMC)
-	if (false == ret) then
-		return false, out
-	end
-
-	return true, out
+	return ret, out
 end
 
 function postinst()
 	local out = "Post installed script called"
+	local ret
+	local updatedev
 
-	ret, out = cmdexec("mkdir -p /tmp/mountedsda3")
+	ret, updatedev = get_update_device_from_boot_device_label("platform1")
+	if (ret == false) then
+		return ret, updatedev .. ", Cannot find update device"
+	end
+
+	local mountpoint = "/tmp/mounted" .. updatedev
+	local mountdev = "/dev/" .. updatedev
+	local servicepath = mountpoint .. "/lib/systemd/system/swupdate.service"
+
+	ret, out = cmdexec("mkdir -p " .. mountpoint)
 	if (false == ret) then
 		return ret, out
 	end
 
-	ret, out = cmdexec("mount /dev/sda3 /tmp/mountedsda3")
+	ret, out = cmdexec("mount " .. mountdev .. " " .. mountpoint)
 	if (false == ret) then
 		return ret, out
 	end
 
-	ret, out = cmdexec("sed -i -e 's/alt/main/' /tmp/mountedsda3/lib/systemd/system/swupdate.service")
+	ret, out = cmdexec("sed -i -e 's/alt/main/' " .. servicepath)
 	if (false == ret) then
 		return ret, out
 	end
 
-	ret, out = cmdexec("sed -i -e 's/-c [0-3]/-c 2/' /tmp/mountedsda3/lib/systemd/system/swupdate.service")
+	ret, out = cmdexec("sed -i -e 's/-c [0-3]/-c 2/' " .. servicepath)
 	if (false == ret) then
 		return ret, out
 	end
 
-	ret, out = cmdexec("umount /tmp/mountedsda3")
+	ret, out = cmdexec("umount " .. mountpoint)
 	if (false == ret) then
 		return ret, out
 	end
 
-	ret, out = cmdexec("rm -rf /tmp/mountedsda3")
+	ret, out = cmdexec("rm -rf " .. mountpoint)
+	if (false == ret) then
+		return ret, out
+	end
+
+	ret, out = cmdexec("rm /dev/updatedev")
 	if (false == ret) then
 		return ret, out
 	end

--- a/recipes-extended/images/pelux-image-update/arp/sw-description
+++ b/recipes-extended/images/pelux-image-update/arp/sw-description
@@ -8,7 +8,7 @@ software = {
                 filename = "%%PELUX_IMAGE_NAME_PLACEHOLDER%%";
                 compressed = true;
                 type = "raw";
-                device = "/dev/sda2";
+                device = "/dev/updatedev";
             });
             scripts: ({
                 filename = "emmcsetup1.lua";
@@ -24,7 +24,7 @@ software = {
                 filename = "%%PELUX_IMAGE_NAME_PLACEHOLDER%%";
                 compressed = true;
                 type = "raw";
-                device = "/dev/sda3";
+                device = "/dev/updatedev";
             });
             scripts: ({
                 filename = "emmcsetup2.lua";

--- a/recipes-extended/images/pelux-image-update/intel-corei7-64/emmcsetup2.lua
+++ b/recipes-extended/images/pelux-image-update/intel-corei7-64/emmcsetup2.lua
@@ -5,11 +5,6 @@ function os.capture(cmd)
 	return s
 end
 
-function file_exists(name)
-	local f=io.open(name,"r")
-	if f~=nil then io.close(f) return true else return false end
-end
-
 function cmdexec(cmd)
 	local ret, s, status = os.execute(cmd)
 	if (status ~= 0) then
@@ -19,109 +14,113 @@ function cmdexec(cmd)
 	return true,""
 end
 
-function preinst()
-	local out
-	local s1
+function get_device_from_boot_device_label(label)
+	local pdev
+	local dev
+
+	pdev = os.capture("lsblk -no PARTLABEL,PKNAME | grep " .. label .. " | awk '{print $2}'")
+
+	dev = os.capture("lsblk -no PARTLABEL,KNAME | grep " .. label .. " | awk '{print $2}'")
+
+	return pdev, dev
+end
+
+function get_update_device_from_boot_device(dev)
+	local part = ""
+	local length = dev:len()-1
+	local num = dev:sub(length, length)
+
+	if ("2" == num) then
+		part = "3"
+	elseif ("3" == num) then
+		part = "2"
+	else
+		return false, "Incorrect Partition number " .. num
+	end
+
+	local updatedev = dev:sub(1, length-1) .. part
+
+	return true, updatedev
+end
+
+function get_update_device_from_boot_device_label(label)
 	local ret
+	local pdev
+	local bootdev
+	local updatedev
 
-	local log = os.tmpname()
+	pdev, bootdev = get_device_from_boot_device_label(label)
 
-	local eMMC = "/dev/sda"
-	ret = file_exists("/dev/sda")
+	ret, updatedev = get_update_device_from_boot_device(bootdev)
 
+	print("Boot Device:", bootdev, "Update Device:", updatedev)
+
+	return ret, updatedev
+end
+
+function preinst()
+	local out = "Pre installed script called"
+	local ret
+	local updatedev
+
+	ret, updatedev = get_update_device_from_boot_device_label("platform1")
 	if (ret == false) then
-		return false, "Cannot find eMMC"
+		return ret, updatedev .. ", Cannot find update device"
 	end
 
-	ret, out = cmdexec("/usr/sbin/sfdisk -d " .. eMMC .. "> /tmp/dumppartitions")
+	ret, out = cmdexec("ln -s /dev/" .. updatedev .. " /dev/updatedev")
 	if (false == ret) then
 		return ret, out
 	end
 
-	-- check if there are two identical partitions
-	-- and create the second one if no available
-	f = io.input("/tmp/dumppartitions")
-	fo = io.output("/tmp/partitions")
-	t = f:read()
-	found = false
-	while (t ~= nil) do
-		j=0
-		j=string.find(t, "/dev/sda3")
-		ret, out = fo:write(t .. "\n")
-		if (ret == nil) then
-			fo:close()
-			f:close()
-			return false, out
-		end
-		if (j == 1) then
-			found=true
-			break
-		end
-		j=string.find(t, "/dev/sda2")
-		if (j == 1) then
-			start, size = string.match(t, "%a+%s*=%s*(%d+), size=%s*(%d+)")
-		end
-		t = f:read()
-	end
-
-	if (found) then
-		f:close()
-		fo:close()
-		return true, out
-	end
-
-	start=start+size
-	partitions = eMMC .. "3 : start=    " .. string.format("%d", start) .. ", size=  " .. size .. ", type=83\n"
-
-	ret, out = fo:write(partitions)
-	fo:close()
-	f:close()
-
-	if (ret == nil) then
-		return false, out
-	end
-
-	out = os.capture("/usr/sbin/sfdisk --force " .. eMMC .. " < /tmp/partitions")
-
-	-- use partprobe to inform the kernel of the new partitions
-
-	ret, out = cmdexec("/usr/sbin/partprobe " .. eMMC)
-	if (false == ret) then
-		return ret, out
-	end
-
-	return true, out
+	return ret, out
 end
 
 function postinst()
 	local out = "Post installed script called"
+	local ret
+	local updatedev
 
-	ret, out = cmdexec("mkdir -p /tmp/mountedsda3")
+	ret, updatedev = get_update_device_from_boot_device_label("platform1")
+	if (ret == false) then
+		return ret, updatedev .. ", Cannot find update device"
+	end
+
+	local mountpoint = "/tmp/mounted" .. updatedev
+	local mountdev = "/dev/" .. updatedev
+	local servicepath = mountpoint .. "/lib/systemd/system/swupdate.service"
+
+	ret, out = cmdexec("mkdir -p " .. mountpoint)
 	if (false == ret) then
 		return ret, out
 	end
 
-	ret, out = cmdexec("mount /dev/sda3 /tmp/mountedsda3")
+	ret, out = cmdexec("mount " .. mountdev .. " " .. mountpoint)
 	if (false == ret) then
 		return ret, out
 	end
 
-	ret, out = cmdexec("sed -i -e 's/alt/main/' /tmp/mountedsda3/lib/systemd/system/swupdate.service")
+	ret, out = cmdexec("sed -i -e 's/alt/main/' " .. servicepath)
 	if (false == ret) then
 		return ret, out
 	end
 
-	ret, out = cmdexec("sed -i -e 's/-c [0-3]/-c 2/' /tmp/mountedsda3/lib/systemd/system/swupdate.service")
+	ret, out = cmdexec("sed -i -e 's/-c [0-3]/-c 2/' " .. servicepath)
 	if (false == ret) then
 		return ret, out
 	end
 
-	ret, out = cmdexec("umount /tmp/mountedsda3")
+	ret, out = cmdexec("umount " .. mountpoint)
 	if (false == ret) then
 		return ret, out
 	end
 
-	ret, out = cmdexec("rm -rf /tmp/mountedsda3")
+	ret, out = cmdexec("rm -rf " .. mountpoint)
+	if (false == ret) then
+		return ret, out
+	end
+
+	ret, out = cmdexec("rm /dev/updatedev")
 	if (false == ret) then
 		return ret, out
 	end

--- a/recipes-extended/images/pelux-image-update/intel-corei7-64/sw-description
+++ b/recipes-extended/images/pelux-image-update/intel-corei7-64/sw-description
@@ -8,7 +8,7 @@ software = {
                 filename = "%%PELUX_IMAGE_NAME_PLACEHOLDER%%";
                 compressed = true;
                 type = "raw";
-                device = "/dev/sda2";
+                device = "/dev/updatedev";
             });
             scripts: ({
                 filename = "emmcsetup1.lua";
@@ -24,7 +24,7 @@ software = {
                 filename = "%%PELUX_IMAGE_NAME_PLACEHOLDER%%";
                 compressed = true;
                 type = "raw";
-                device = "/dev/sda3";
+                device = "/dev/updatedev";
             });
             scripts: ({
                 filename = "emmcsetup2.lua";

--- a/scripts/lib/wic/canned-wks/cfg
+++ b/scripts/lib/wic/canned-wks/cfg
@@ -8,9 +8,9 @@ save_env default
 
 # Boot entries
 menuentry 'bootA'{
-    linux /bzImage root=/dev/sda2 rootwait rootfstype=ext4 console=ttyS0,115200 console=tty0 i915.enable_execlists=0
+    linux /bzImage root=PARTUUID=4f531a2e-d931-4308-8ccd-d2262b910bad rootwait rootfstype=ext4 console=ttyS0,115200 console=tty0 i915.enable_execlists=0
 }
 
 menuentry 'bootB'{
-    linux /bzImage root=/dev/sda3 rootwait rootfstype=ext4 console=ttyS0,115200 console=tty0 i915.enable_execlists=0
+    linux /bzImage root=PARTUUID=12586f0b-38ad-42b8-8340-fe9d08db7139 rootwait rootfstype=ext4 console=ttyS0,115200 console=tty0 i915.enable_execlists=0
 }

--- a/scripts/lib/wic/canned-wks/mkefidisk-multiboot.wks
+++ b/scripts/lib/wic/canned-wks/mkefidisk-multiboot.wks
@@ -2,12 +2,12 @@
 # long-description: Creates a partitioned EFI disk image that the user
 # can directly dd to boot media.
 
-part /boot --source bootimg-efi --sourceparams="loader=grub-efi" --ondisk sda --label msdos --active --align 1024
+part /boot --source bootimg-efi --sourceparams="loader=grub-efi" --label msdos --active --align 1024 --uuid 279767e4-75b9-4b6b-92ca-cddbe821e3a6
 
-part / --source rootfs --ondisk sda --fstype=ext4 --label platform --align 1024
+part / --source rootfs --fstype=ext4 --label platform1 --align 1024 --uuid 4f531a2e-d931-4308-8ccd-d2262b910bad
 
-part / --source rootfs --ondisk sda --fstype=ext4 --label platform --align 1024
+part / --source rootfs --fstype=ext4 --label platform2 --align 1024 --uuid 12586f0b-38ad-42b8-8340-fe9d08db7139
 
-part swap --ondisk sda --size 44 --label swap1 --fstype=swap
+part swap --size 44 --label swap1 --fstype=swap --uuid 36e409e3-bec6-4d36-9d93-51f917421531
 
 bootloader --configfile cfg --ptable gpt --timeout=5 --append="rootfstype=ext4 console=ttyS0,115200 console=tty0"


### PR DESCRIPTION
NUC and ARP were assumed to boot from /dev/sda.
However, the boot device could be other than the
usb. In that case hardcoded device /dev/sda would
fail to boot. The solution is to use manually
generated PARTUUIDs hardcoded in wks file instead
of hardcoded device names, which could change. The
PARTUUIDs will remain the same even if the boot
device is changed. This also affected the swupdate
which also assumed the device to be /dev/sda.
Software update is modifed to use PARTLABEL to
detect the boot device. Since PARTUUID and
PARTLABEL have one to one mapping, PARTUUID
can be used in software update scripts. However,
for better readability reasons PARTLABEL are used.

Signed-off-by: Tariq Ansari <tansari@luxoft.com>