### PR TITLE
softwarecontainer: run neptune Map app in container

### DIFF
--- a/layers/b2qt/recipes-qt/automotive/qtapplicationmanager/sc-config.yaml
+++ b/layers/b2qt/recipes-qt/automotive/qtapplicationmanager/sc-config.yaml
@@ -6,6 +6,7 @@ formatType: am-configuration
 ---
 containers:
   selection:
+    - com.pelagicore.map: "softwarecontainer"
     - com.pelagicore.calendar: "softwarecontainer"
     - "*": "process"
 

--- a/recipes-containers/softwarecontainer/files/io.qt.ApplicationManager.Application.json
+++ b/recipes-containers/softwarecontainer/files/io.qt.ApplicationManager.Application.json
@@ -36,6 +36,40 @@
           ]
         },
         {
+          "id": "file",
+          "config": [
+            {
+              "path-host": "/run",
+              "path-container": "/run",
+              "read-only": true
+            },
+            {
+              "path-host": "/etc/ssl",
+              "path-container": "/etc/ssl",
+              "read-only": true
+            }
+          ]
+        },
+        {
+          "id":"network",
+          "config": [
+            {
+              "direction": "OUTGOING",
+              "allow": [
+                { "host": "*", "protocols": ["udp", "tcp"], "ports": 53 },
+                { "host": "*", "protocols": "tcp", "ports": [80, 443] }
+              ]
+            },
+            {
+              "direction": "INCOMING",
+              "allow": [
+                { "host": "*", "protocols": ["udp", "tcp"], "ports": 53 },
+                { "host": "*", "protocols": "tcp", "ports": [80, 443] }
+              ]
+            }
+          ]
+        },
+        {
           "id": "devicenode",
           "config": [
             {


### PR DESCRIPTION
This runs neptune Map application in softwarecontainer.
It requires networkgateway to be configured in order to
access api.mapbox.com API which provides map information
to render. Filegateway is also configured since the
iptables used by networkgateway require to lock
/run/xtables.lock when running commands. /etc/ssl is
also mounted through filegateway. This is needed for SSL
certificates needed to access https://api.mapbox.com.

Signed-off-by: Tariq Ansari <tansari@luxoft.com>