### PR TITLE
connman: disable dns proxy

### DIFF
--- a/recipes-connectivity/connman/connman/disable_connman_dns_proxy.patch
+++ b/recipes-connectivity/connman/connman/disable_connman_dns_proxy.patch
@@ -1,0 +1,13 @@
+diff --git a/src/connman.service.in b/src/connman.service.in
+index 7376346e..a652b0a5 100644
+--- a/src/connman.service.in
++++ b/src/connman.service.in
+@@ -11,7 +11,7 @@ Wants=network.target
+ Type=dbus
+ BusName=net.connman
+ Restart=on-failure
+-ExecStart=@sbindir@/connmand -n
++ExecStart=@sbindir@/connmand -n -r
+ StandardOutput=null
+ CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RAW CAP_SYS_TIME CAP_SYS_MODULE CAP_SYS_ADMIN
+ ProtectHome=true

--- a/recipes-connectivity/connman/connman_%.bbappend
+++ b/recipes-connectivity/connman/connman_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://disable_connman_dns_proxy.patch"


### PR DESCRIPTION
DNS proxy was enabled for connman by default. This allowed
connman to route DNS traffic to itself by setting nameserver
to loopback IP in resolv.conf. Disabling the dns proxy means
that applications directly call DNS server for address
resolution instead of going through connman dns proxy.

The motivation for this is that some applications running
inside softwarecontainer requires network access and will
direct DNS traffic to the loopback IP inside the container.
However, connman is not running inside the container, hence
unable to resolve address. Disabling connman dns proxy means
that container applications will directly call DNS server
for address resolution.

This is a temporary workaround to get container applications
with network access to work. Ideally, it should be possible
to setup container to either access host's connman dns proxy
or resolve ip addresses in its own way, irrespective of how
addresses are resolved on the host.

Signed-off-by: Tariq Ansari <tansari@luxoft.com>