### PR TITLE
connman: refresh disable dns proxy patch

### DIFF
--- a/recipes-connectivity/connman/connman/disable_connman_dns_proxy.patch
+++ b/recipes-connectivity/connman/connman/disable_connman_dns_proxy.patch
@@ -1,13 +1,21 @@
+From d6872a0951edac438e965b1bab09778ebfa9578f Mon Sep 17 00:00:00 2001
+From: Tariq Ansari <tansari@luxoft.com>
+Date: Wed, 8 May 2019 15:36:21 +0200
+
+---
+ src/connman.service.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 diff --git a/src/connman.service.in b/src/connman.service.in
-index 7376346e..a652b0a5 100644
+index dab48bc..3e7872e 100644
 --- a/src/connman.service.in
 +++ b/src/connman.service.in
-@@ -11,7 +11,7 @@ Wants=network.target
+@@ -12,7 +12,7 @@ Conflicts=systemd-resolved.service
  Type=dbus
  BusName=net.connman
  Restart=on-failure
 -ExecStart=@sbindir@/connmand -n
 +ExecStart=@sbindir@/connmand -n -r
  StandardOutput=null
- CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RAW CAP_SYS_TIME CAP_SYS_MODULE CAP_SYS_ADMIN
+ CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RAW CAP_SYS_TIME CAP_SYS_MODULE
  ProtectHome=true


### PR DESCRIPTION
Patch hunks. Refresh the patch, so it applies cleanly.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>