### PR TITLE
core-image-pelux: add connectivity-manager

### DIFF
--- a/classes/core-image-pelux.bbclass
+++ b/classes/core-image-pelux.bbclass
@@ -52,6 +52,11 @@ IMAGE_INSTALL_remove_qemux86-64 = "\
     swupdate \
 "
 
+# Connectivity Manager
+IMAGE_INSTALL_append = "\
+    connectivity-manager \
+"
+
 IMAGE_INSTALL_append_arp = "\
     arp-driver \
 "


### PR DESCRIPTION
We should probably not keep adding components unconditionally like this to core-image-pelux*.bbclass . Do it for connectivity-manager for now and then we need to come back and think about how we should handle "features" at some later point (soon (tm)).

Depends on https://github.com/Pelagicore/meta-bistro/pull/246 .