### PR TITLE
local.conf.sample: add smoketest to qemu config

### DIFF
--- a/conf/variant/qemu-x86-64_nogfx/local.conf.sample
+++ b/conf/variant/qemu-x86-64_nogfx/local.conf.sample
@@ -1,3 +1,33 @@
 require conf/variant/common/local.conf
 
 MACHINE = "qemux86-64"
+
+# Target Static IP address. Needed for ssh and ping test.
+STATIC_IP_ADDRESS = "192.168.7.2"
+
+# Enable testing
+INHERIT += " \
+    testimage \
+    testexport \
+"
+
+# All test suites to run
+TEST_SUITES = " \
+    date \
+    ping \
+    ssh \
+    scp \
+    df \
+    parselogs \
+    softwarecontainer \
+    node_state_manager \
+    dlt_daemon \
+    systemd.SystemdBasicTests.test_systemd_basic \
+    systemd.SystemdBasicTests.test_systemd_failed \
+    systemd.SystemdBasicTests.test_systemd_list \
+    systemd.SystemdJournalTests.test_systemd_journal \
+    rpm.RpmBasicTest \
+    rpm.RpmInstallRemoveTest.test_rpm_install \
+    rpm.RpmInstallRemoveTest.test_rpm_query_nonroot \
+    rpm.RpmInstallRemoveTest.test_rpm_remove \
+"


### PR DESCRIPTION
Currently, when one needs to run smoketests on qemu, the
local.conf file of the qemu-x86-64_nogfx variant needs to
be manually modified to enable running of the tests. The
tests and the configuration required to run these tests
are located in conf/test-scripts/local.conf.appendix file
in pelux-manifest. For running nightly smoke tests the
configuration from this file is automatically extracted
and appended to the qemu local.conf, but to run the tests
locally, one needs to copy the config to the local.conf.
This commit adds this configuration to local.conf.sample
of qemu variant, so the tests becomes part of the qemu.
With this change, the ci-scripts/yocto.groovy script in
pelux-manifest also needs to be updated to remove the
automatic copying of test config to the local.conf file.

Signed-off-by: Tariq Ansari <tansari@luxoft.com>