### PR TITLE
core-image-pelux-qtauto: add qttools-tools

### DIFF
--- a/classes/core-image-pelux-qtauto.bbclass
+++ b/classes/core-image-pelux-qtauto.bbclass
@@ -13,6 +13,7 @@ QTAUTO_COMPONENTS = " \
     qtapplicationmanager \
     qtivi \
     qtivi-mopidy-plugin \
+    qttools-tools \
     qtvirtualkeyboard \
 "
 


### PR DESCRIPTION
qttools-tools contains qtdiag app which is used by the Neptune's
Diagnostic application.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>