### PR TITLE
layer.conf: add Warrior to LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -23,4 +23,4 @@ BBFILES += "${@' '.join('${LAYERDIR}/layers/%s/recipes*/*/*.bbappend' % layer \
 BBFILES += "${@' '.join('${LAYERDIR}/layers/%s/recipes*/*/*.bb' % layer \
                for layer in BBFILE_COLLECTIONS.split())}"
 
-LAYERSERIES_COMPAT_pelux-layer = "sumo thud"
+LAYERSERIES_COMPAT_pelux-layer = "sumo thud warrior"

--- a/meta-intel-extras/conf/layer.conf
+++ b/meta-intel-extras/conf/layer.conf
@@ -13,4 +13,4 @@ BBFILE_PATTERN_pelux-bsp-intel-layer := "^${LAYERDIR}/"
 
 BBFILE_PRIORITY_pelux-bsp-intel-layer = "10"
 
-LAYERSERIES_COMPAT_pelux-bsp-intel-layer = "sumo thud"
+LAYERSERIES_COMPAT_pelux-bsp-intel-layer = "sumo thud warrior"

--- a/meta-rpi-extras/conf/layer.conf
+++ b/meta-rpi-extras/conf/layer.conf
@@ -13,4 +13,4 @@ BBFILE_PATTERN_pelux-bsp-rpi-layer := "^${LAYERDIR}/"
 
 BBFILE_PRIORITY_pelux-bsp-rpi-layer = "10"
 
-LAYERSERIES_COMPAT_pelux-bsp-rpi-layer = "sumo thud"
+LAYERSERIES_COMPAT_pelux-bsp-rpi-layer = "sumo thud warrior"


### PR DESCRIPTION
Add Warrior to LAYERSERIES_COMPAT in layer.conf since the ACRN
configuration requires it.

Signed-off-by: Viktor Sjölind <vsjolind@luxoft.com>