### PR TITLE
core-image-pelux-minimal: add ssh server to non-dev images

### DIFF
--- a/layers/b2qt/recipes-core/images/core-image-pelux-qtauto-neptune-dev.bb
+++ b/layers/b2qt/recipes-core/images/core-image-pelux-qtauto-neptune-dev.bb
@@ -1,6 +1,6 @@
 #
 #   Copyright (C) 2017 Pelagicore AB
-#   Copyright (C) 2018 Luxoft Sweden AB
+#   Copyright (C) 2019 Luxoft Sweden AB
 #   SPDX-License-Identifier: MIT
 #
 
@@ -9,9 +9,8 @@ DESCRIPTION = "Reference PELUX image with QtAuto frontend"
 require core-image-pelux-qtauto-neptune.bb
 
 # Development stuff
-IMAGE_FEATURES += "tools-debug tools-testapps ssh-server-openssh"
+IMAGE_FEATURES += "tools-debug tools-testapps"
 IMAGE_INSTALL += "\
-	coreutils \
 	openssh-sftp-server \
 	packagegroup-bistro-debug-utils \
 	vim \

--- a/layers/b2qt/recipes-core/images/core-image-pelux-qtauto-neptune.bb
+++ b/layers/b2qt/recipes-core/images/core-image-pelux-qtauto-neptune.bb
@@ -1,6 +1,6 @@
 #
 #   Copyright (C) 2017 Pelagicore AB
-#   Copyright (C) 2018 Pelagicore AB
+#   Copyright (C) 2019 Luxoft Sweden AB
 #   SPDX-License-Identifier: MIT
 #
 
@@ -8,6 +8,8 @@ DESCRIPTION = "Reference PELUX image with QtAuto frontend"
 
 inherit core-image-pelux-qtauto
 inherit populate_sdk_qt5
+
+IMAGE_FEATURES += "ssh-server-openssh"
 
 # This image uses neptune as the reference UI, which is one of the addons in Qt Auto packagegroup
 IMAGE_INSTALL_append = "\

--- a/recipes-core/images/core-image-pelux-minimal-dev.bb
+++ b/recipes-core/images/core-image-pelux-minimal-dev.bb
@@ -1,16 +1,15 @@
 #
 #   Copyright (C) 2017 Pelagicore AB
-#   Copyright (C) 2018 Luxoft Sweden AB
+#   Copyright (C) 2019 Luxoft Sweden AB
 #   SPDX-License-Identifier: MIT
 #
 
 require core-image-pelux-minimal.bb
 
 # Development stuff
-IMAGE_FEATURES += "tools-debug tools-testapps ssh-server-openssh"
+IMAGE_FEATURES += "tools-debug tools-testapps"
 
 IMAGE_INSTALL_append = "\
-    coreutils \
     openssh-sftp-server \
     packagegroup-bistro-debug-utils \
     vim \

--- a/recipes-core/images/core-image-pelux-minimal.bb
+++ b/recipes-core/images/core-image-pelux-minimal.bb
@@ -1,12 +1,14 @@
 #
 #   Copyright (C) 2017 Pelagicore AB
-#   Copyright (C) 2018 Luxoft Sweden AB
+#   Copyright (C) 2019 Luxoft Sweden AB
 #   SPDX-License-Identifier: MIT
 #
 
-DESCRIPTION = "Image for creating a Pelux image"
+DESCRIPTION = "Image for creating a PELUX image"
 
 inherit core-image-pelux
+
+IMAGE_FEATURES += "ssh-server-openssh"
 
 IMAGE_INSTALL_append = "\
     coreutils \


### PR DESCRIPTION
Added openssh-server to non-dev images.

Also removed coreutils from dev image since it is already part of the
core-image-pelux-minimal which is inherited by dev image.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>