### PR TITLE
pelux.conf: set DISTRO_VERSION by running git describe

### DIFF
--- a/conf/distro/git_describe_version.inc
+++ b/conf/distro/git_describe_version.inc
@@ -1,0 +1,22 @@
+#
+#   Copyright (C) 2019 Luxoft Sweden AB
+#   SPDX-License-Identifier: MIT
+#
+
+# Generates a version string for DISTRO_VERSION by running git describe.
+#
+# Assumes there is a tag in the format "[v]<major>.<minor>[-e][</|->Yocto release name]". Optional
+# leading 'v' is stripped and '/' is replaced with '-'. Having '/' in DISTRO_VERSION is problematic
+# (probably due to it being used in file names).
+
+def git_describe_version(repo_dir_path, default):
+    import subprocess
+
+    git_args = ['git', '-C', repo_dir_path, 'describe', '--tags', '--dirty']
+    ret = subprocess.run(git_args, stdout=subprocess.PIPE, universal_newlines=True)
+
+    if ret.returncode != 0:
+        bb.warn('Failed to run "git describe" in ' + repo_dir_path + ', using "' + default + '"')
+        return default
+
+    return ret.stdout.strip().lstrip('v').replace('/', '-')

--- a/conf/distro/pelux.conf
+++ b/conf/distro/pelux.conf
@@ -5,11 +5,14 @@
 #
 
 require conf/distro/poky.conf
+require git_describe_version.inc
+
+GIT_DESCRIBE_REPO_DIR := "${@os.path.abspath(os.path.join(d.getVar('COREBASE'), '../../.repo/manifests'))}"
 
 MAINTAINER = "Gordan Markuš <gordan.markus@pelagicore.com>"
 DISTRO = "pelux"
 DISTRO_NAME = "PELUX"
-DISTRO_VERSION = "master"
+DISTRO_VERSION := "${@git_describe_version(d.getVar('GIT_DESCRIBE_REPO_DIR'), default='master')}"
 TARGET_VENDOR = "-pelux"
 
 # Add distro features

--- a/recipes-core/os-release/os-release.bbappend
+++ b/recipes-core/os-release/os-release.bbappend
@@ -1,1 +1,1 @@
-VERSION = "${DISTRO_VERSION}${@' (Based on Yocto %s)' % DISTRO_CODENAME if 'DISTRO_CODENAME' in d else ''}"
+VERSION = "${DISTRO_VERSION} (Based on Yocto)"


### PR DESCRIPTION
In the manifests repository. Will make it so it is possible to know what revision of pelux-manfiests was used when building an image.
    
Assign DISTRO_VERSION with := to avoid running git describe every time DISTRO_VERSION is evaluated.
    
COREBASE points to the sources/poky directory of a PELUX checkout. Using "../../.repo/manifests" means that we rely on the current folder structure of a PELUX checkout to find the repository to run git describe in. Should be OK. If it ever changes we probably need to modify other paths, this will just be one more. A warning is printed by BitBake if the repository is not found and a default string is used instead.
    
Since the Yocto version is used in the names of tags in pelux-manifests, remove it from VERSION in os-release.bbappend by removing DISTRO_CODENAME. Example of /usr/lib/os-release generated with this change:

```
ID="pelux"
NAME="PELUX"
VERSION="1.0-pyro-200-g17d4519 (Based on Yocto)"
VERSION_ID="1.0-pyro-200-g17d4519"
PRETTY_NAME="PELUX 1.0-pyro-200-g17d4519 (Based on Yocto)"
```

If a build is made on a tag, the number of commits following a tag ("-200") and the short hash ("-g17d4519") will not be included. I.e. VERSION_ID will be "<Major>.<Minor>-<Yocto code name>" for releases.

v1.0/pyro is currently the only tag we have on the master branch so the version will be "1.0-pyro..." until that changes.