### PR TITLE
persistence-administrator: add GCC 8 fix

### DIFF
--- a/recipes-temporary-patches/persistence-administrator/persistence-administrator/0001-Make-snprintf-comply-with-Werror-format-security.patch
+++ b/recipes-temporary-patches/persistence-administrator/persistence-administrator/0001-Make-snprintf-comply-with-Werror-format-security.patch
@@ -1,0 +1,60 @@
+From d5706685bf17d7c2f92685005257a436d50f8b75 Mon Sep 17 00:00:00 2001
+From: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>
+Date: Tue, 11 Jun 2019 17:34:33 +0200
+Subject: [PATCH] Make snprintf comply with -Werror=format-security
+
+Fixes the following error when bulding with GCC 8.2 and
+-Werror=format-security:
+
+  error: format not a string literal and no format arguments
+  [-Werror=format-security]
+
+Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>
+---
+ Administrator/src/ssw_pers_admin_common.c                 | 2 +-
+ test/pers_svc_test/src/test_pas_import_source_content.c   | 2 +-
+ test/pers_svc_test/src/test_pas_recovery_backup_content.c | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Administrator/src/ssw_pers_admin_common.c b/Administrator/src/ssw_pers_admin_common.c
+index df4c0e1..0ae30b7 100644
+--- a/Administrator/src/ssw_pers_admin_common.c
++++ b/Administrator/src/ssw_pers_admin_common.c
+@@ -595,7 +595,7 @@ sint_t persadmin_compress(pstr_t compressTo, pstr_t compressFrom)
+     }
+ 
+     memset(pchParentPath, 0, sizeof(pchParentPath));
+-    snprintf(pchParentPath, sizeof(pchParentPath), compressFrom);
++    snprintf(pchParentPath, sizeof(pchParentPath), "%s", compressFrom);
+     pchStrPos = strrchr(pchParentPath, '/');
+     if(NIL != pchStrPos)
+     {
+diff --git a/test/pers_svc_test/src/test_pas_import_source_content.c b/test/pers_svc_test/src/test_pas_import_source_content.c
+index b0aeaa4..101d4aa 100644
+--- a/test/pers_svc_test/src/test_pas_import_source_content.c
++++ b/test/pers_svc_test/src/test_pas_import_source_content.c
+@@ -778,7 +778,7 @@ static sint_t persadmin_compress(pstr_t compressTo, pstr_t compressFrom)
+     }
+ 
+     memset(pchParentPath, 0, sizeof(pchParentPath));
+-    snprintf(pchParentPath, sizeof(pchParentPath), compressFrom);
++    snprintf(pchParentPath, sizeof(pchParentPath), "%s", compressFrom);
+     pchStrPos = strrchr(pchParentPath, '/');
+     if(NIL != pchStrPos)
+     {
+diff --git a/test/pers_svc_test/src/test_pas_recovery_backup_content.c b/test/pers_svc_test/src/test_pas_recovery_backup_content.c
+index 93fb025..35d2435 100644
+--- a/test/pers_svc_test/src/test_pas_recovery_backup_content.c
++++ b/test/pers_svc_test/src/test_pas_recovery_backup_content.c
+@@ -775,7 +775,7 @@ static sint_t persadmin_compress(pstr_t compressTo, pstr_t compressFrom)
+     }
+ 
+     memset(pchParentPath, 0, sizeof(pchParentPath));
+-    snprintf(pchParentPath, sizeof(pchParentPath), compressFrom);
++    snprintf(pchParentPath, sizeof(pchParentPath), "%s", compressFrom);
+     pchStrPos = strrchr(pchParentPath, '/');
+     if(NIL != pchStrPos)
+     {
+-- 
+2.17.1
+

--- a/recipes-temporary-patches/persistence-administrator/persistence-administrator_%.bbappend
+++ b/recipes-temporary-patches/persistence-administrator/persistence-administrator_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-Make-snprintf-comply-with-Werror-format-security.patch"


### PR DESCRIPTION
Fixes compilation with GCC 8 used by Thud.

Pull request: https://github.com/GENIVI/persistence-administrator/pull/5

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>