### PR TITLE
core-image-pelux: add gdbus-codegen-glibmm to SDK

### DIFF
--- a/classes/core-image-pelux.bbclass
+++ b/classes/core-image-pelux.bbclass
@@ -63,6 +63,7 @@ IMAGE_INSTALL_append_arp = "\
 
 TOOLCHAIN_HOST_TASK += "\
     nativesdk-cmake \
+    nativesdk-gdbus-codegen-glibmm \
     nativesdk-meson \
 "
 


### PR DESCRIPTION
Needed to build template-dbus-service and components based on it.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>