### PR TITLE
local.conf:create a bmap file

### DIFF
--- a/conf/variant/arp-qtauto/local.conf.sample
+++ b/conf/variant/arp-qtauto/local.conf.sample
@@ -4,6 +4,8 @@ MACHINE = "arp"
 
 EFI_PROVIDER = "grub-efi"
 
+IMAGE_FSTYPES += "wic wic.bmap"
+
 PREFERRED_PROVIDER_iasl-native = "iasl-native"
 
 WKS_FILE = "mkefidisk-multiboot.wks"

--- a/conf/variant/arp/local.conf.sample
+++ b/conf/variant/arp/local.conf.sample
@@ -2,6 +2,8 @@ require conf/variant/common/local.conf
 
 MACHINE = "arp"
 
+IMAGE_FSTYPES += "wic wic.bmap"
+
 EFI_PROVIDER = "grub-efi"
 
 PREFERRED_PROVIDER_iasl-native = "iasl-native"

--- a/conf/variant/intel-qtauto/local.conf.sample
+++ b/conf/variant/intel-qtauto/local.conf.sample
@@ -2,6 +2,8 @@ require conf/variant/common/local.conf
 
 MACHINE = "intel-corei7-64"
 
+IMAGE_FSTYPES += "wic wic.bmap"
+
 EFI_PROVIDER = "grub-efi"
 
 PREFERRED_PROVIDER_iasl-native = "iasl-native"

--- a/conf/variant/intel/local.conf.sample
+++ b/conf/variant/intel/local.conf.sample
@@ -2,6 +2,8 @@ require conf/variant/common/local.conf
 
 MACHINE = "intel-corei7-64"
 
+IMAGE_FSTYPES += "wic wic.bmap"
+
 EFI_PROVIDER = "grub-efi"
 
 PREFERRED_PROVIDER_iasl-native = "iasl-native"


### PR DESCRIPTION
Since our images have grown in size, dd-ing takes a long time. Bmap
tools allow us to take advantage of sparse files and reduce time needed
for flashing of an image.

Signed-off-by: Fisnik Hajredini <fhajredini@luxoft.com>