### PR TITLE
neptune3-ui: hide mouse cursor

### DIFF
--- a/layers/b2qt/recipes-qt/automotive/neptune3-ui/neptune.service
+++ b/layers/b2qt/recipes-qt/automotive/neptune3-ui/neptune.service
@@ -14,6 +14,7 @@ Environment=QT_IM_MODULE=qtvirtualkeyboard
 Environment=XDG_RUNTIME_DIR=/tmp
 Environment=QTWEBENGINE_CHROMIUM_FLAGS="--no-sandbox --single-process"
 Environment=WAYLAND_DISPLAY="qtam-wayland-0"
+Environment=QT_QPA_EGLFS_HIDECURSOR=1
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
According to the Qt docs[1], if libudev support is not present, the
mouse cursor always show up unless explicitly disabled via the
environment variable.

udev packageconfig is enabled by default in qtbase, but for some
reason only works on Raspberry Pi, and not on Intel.

[1] https://doc.qt.io/Qt-5/embedded-linux.html#mouse

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>