### PR TITLE
Include mount parts of udev-extraconf in Poky

### DIFF
--- a/classes/core-image-pelux.bbclass
+++ b/classes/core-image-pelux.bbclass
@@ -19,6 +19,12 @@ IMAGE_INSTALL_append = "\
     ${@bb.utils.contains("COMBINED_FEATURES", "bluetooth", "packagegroup-tools-bluetooth", "", d)} \
 "
 
+# Include udev-extraconf for automatic mounting of pluggable mass storage
+# devices (other parts are stripped out).
+IMAGE_INSTALL_append = "\
+    udev-extraconf \
+"
+
 # GENIVI components
 IMAGE_INSTALL_append = "\
     dlt-daemon         \

--- a/recipes-core/udev-extraconf/udev-extraconf/0001-udev-extraconf-allow-labels-and-UUID-s-in-mount-blac.patch
+++ b/recipes-core/udev-extraconf/udev-extraconf/0001-udev-extraconf-allow-labels-and-UUID-s-in-mount-blac.patch
@@ -1,0 +1,51 @@
+From 1aa8f8af363518578437ac6921754e1e175b6943 Mon Sep 17 00:00:00 2001
+From: Martin Ejdestig <mejdestig@luxoft.com>
+Date: Tue, 25 Jun 2019 15:06:06 +0200
+Subject: [PATCH] udev-extraconf: allow labels and UUID:s in mount blacklists
+
+Needed for systems were device nodes are not known when an image is built
+but there are partitions that should not be automatically mounted.
+
+Example of output line from added lsblk invocation:
+
+LABEL="Test" PARTLABEL="Test" UUID="8097dcca-dd50-4e2d-8be0-d242f29a6747" PARTUUID="85aaf782-01
+
+Removing " with sed allows for using the same format in the blacklist files
+as in /etc/fstab, were " is not used, to refer to a device.
+
+Signed-off-by: Martin Ejdestig <mejdestig@luxoft.com>
+---
+ meta/recipes-core/udev/udev-extraconf/mount.sh | 15 ++++++++++-----
+ 1 file changed, 10 insertions(+), 5 deletions(-)
+
+diff --git a/meta/recipes-core/udev/udev-extraconf/mount.sh b/meta/recipes-core/udev/udev-extraconf/mount.sh
+index 3ee67b1318..f655c7003d 100644
+--- a/meta/recipes-core/udev/udev-extraconf/mount.sh
++++ b/meta/recipes-core/udev/udev-extraconf/mount.sh
+@@ -26,13 +26,18 @@ fi
+ 
+ PMOUNT="/usr/bin/pmount"
+ 
++# Allow for blacklisting devices with device names, LABEL/PARTLABEL=<label> and UUID/PARTUUID=<uuid>.
++LSBLK_OUTPUT=`lsblk -P -o LABEL,PARTLABEL,UUID,PARTUUID $DEVNAME | sed s/\"//g`
++
+ for line in `grep -h -v ^# /etc/udev/mount.blacklist /etc/udev/mount.blacklist.d/*`
+ do
+-	if [ ` expr match "$DEVNAME" "$line" ` -gt 0 ];
+-	then
+-		logger "udev/mount.sh" "[$DEVNAME] is blacklisted, ignoring"
+-		exit 0
+-	fi
++	for m in $DEVNAME $LSBLK_OUTPUT; do
++		if [ ` expr match "$m" "$line" ` -gt 0 ];
++		then
++			logger "udev/mount.sh" "[$DEVNAME] is blacklisted, ignoring"
++			exit 0
++		fi
++	done
+ done
+ 
+ automount_systemd() {
+-- 
+2.22.0
+

--- a/recipes-core/udev-extraconf/udev-extraconf/pelux-roots.blacklist
+++ b/recipes-core/udev-extraconf/udev-extraconf/pelux-roots.blacklist
@@ -1,0 +1,2 @@
+LABEL=platform1
+LABEL=platform2

--- a/recipes-core/udev-extraconf/udev-extraconf_%.bbappend
+++ b/recipes-core/udev-extraconf/udev-extraconf_%.bbappend
@@ -1,0 +1,16 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI +=  "\
+    file://0001-udev-extraconf-allow-labels-and-UUID-s-in-mount-blac.patch;striplevel=5 \
+    file://pelux-roots.blacklist \
+"
+
+do_install_append() {
+    install -m 0644 ${WORKDIR}/pelux-roots.blacklist ${D}${sysconfdir}/udev/mount.blacklist.d
+
+    # Only want mount parts of udev-extraconf.
+    rm ${D}${sysconfdir}/udev/rules.d/autonet.rules
+    rm ${D}${sysconfdir}/udev/rules.d/localextra.rules
+    rm ${D}${sysconfdir}/udev/scripts/network.sh
+}
+


### PR DESCRIPTION
Will make it so pluggable mass storage devices are automatically mounted under /run/media/ when inserted.

Since PELUX has two root partitions for swupdate, one that is actually mounted at / and one that is not mounted at all, they need to be blacklisted from the script that is run when a mass storage device is
detected. If it is not, the rootfs that is not / will be mounted under /run/media/. mount.sh in udev-extraconf is extended with the functionality to use UUID:s or labels to blacklist devices so that this can be reliable done in PELUX (using the platform1 and platform2 labels).

Still some verification left to do. (E.g. not exactly sure why secondary / did not show up before the udev-extraconf patch was added on RPI.)