### PR TITLE
core-image-pelux: remove unnecessary IMAGE_FSTYPES

### DIFF
--- a/classes/core-image-pelux.bbclass
+++ b/classes/core-image-pelux.bbclass
@@ -68,7 +68,6 @@ TOOLCHAIN_HOST_TASK += "\
 "
 
 IMAGE_ROOTFS_SIZE ?= "1000000"
-IMAGE_FSTYPES ?= "ext3 sdcard"
 
 # This is needed for SWupdate artifacts
 IMAGE_FSTYPES += "ext3.gz"


### PR DESCRIPTION
We are not using sdcard anywhere and ext3 is already set in BSP layers,
e.g. meta-intel and meta-rapsberrypi.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>