### PR TITLE
core-image-pelux-minimal-dev: remove tools-testapps

### DIFF
--- a/layers/b2qt/recipes-core/images/core-image-pelux-qtauto-neptune-dev.bb
+++ b/layers/b2qt/recipes-core/images/core-image-pelux-qtauto-neptune-dev.bb
@@ -9,7 +9,7 @@ DESCRIPTION = "Reference PELUX image with QtAuto frontend"
 require core-image-pelux-qtauto-neptune.bb
 
 # Development stuff
-IMAGE_FEATURES += "tools-debug tools-testapps"
+IMAGE_FEATURES += "tools-debug"
 IMAGE_INSTALL += "\
 	openssh-sftp-server \
 	packagegroup-bistro-debug-utils \

--- a/recipes-core/images/core-image-pelux-minimal-dev.bb
+++ b/recipes-core/images/core-image-pelux-minimal-dev.bb
@@ -7,7 +7,7 @@
 require core-image-pelux-minimal.bb
 
 # Development stuff
-IMAGE_FEATURES += "tools-debug tools-testapps"
+IMAGE_FEATURES += "tools-debug"
 
 IMAGE_INSTALL_append = "\
     openssh-sftp-server \


### PR DESCRIPTION
tools-testapps packagegroup is comprised of tools we are not using.

LPT package alone takes about 20 minutes to build on a good machine
and occupies 250 MB of space on the filesystem.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>