### PR TITLE
qtivi-mopidy-plugin: bump revision

### DIFF
--- a/layers/b2qt/recipes-multimedia/qtivi-mopidy-plugin/qtivi-mopidy-plugin_git.bb
+++ b/layers/b2qt/recipes-multimedia/qtivi-mopidy-plugin/qtivi-mopidy-plugin_git.bb
@@ -8,7 +8,7 @@ DEPENDS = "qtbase qtwebsockets qtivi"
 RDEPENDS_${PN} = "qtivi"
 
 SRC_URI = "git://github.com/Pelagicore/qtivi-mopidy-plugin.git;protocol=https"
-SRCREV = "538a7ba9940e13a4028c5258a8ace5693429e1c9"
+SRCREV = "237d75b2f8f3987340d3be9214cb17622d2146b9"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Changelog:
- Adapt to Qt IVI 5.13
- Use Q_UNUSED for unused variables
- Avoid using sudo in Jenkins job
- Pass local user UID and GID to Docker

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>