### PR TITLE
core-image-pelux: add user-identification-manager

### DIFF
--- a/classes/core-image-pelux.bbclass
+++ b/classes/core-image-pelux.bbclass
@@ -34,6 +34,7 @@ IMAGE_INSTALL_append = "\
     connectivity-manager \
     libsocketcan \
     mopidy \
+    user-identification-manager \
 "
 
 IMAGE_INSTALL_append_arp = "\


### PR DESCRIPTION
Add it to the "to be restructured later" IMAGE_INSTALL_append section since currently nothing uses it. There is a command line tool (uimcli) and a test source (MSD) that can be used to verify that the basic functionality of the daemon works. See https://github.com/Pelagicore/user-identification-manager/README.md for more information.

Depends on https://github.com/Pelagicore/meta-bistro/pull/253 .