### PR TITLE
wic image for RPI and adding media partition

### DIFF
--- a/conf/variant/rpi-qtauto/local.conf.sample
+++ b/conf/variant/rpi-qtauto/local.conf.sample
@@ -1,5 +1,9 @@
 require conf/variant/common/local.conf
 
+WKS_FILE = "raspberrypi.wks"
+
+IMAGE_FSTYPES_append = " wic wic.bmap wic.bz2"
+
 MACHINE = "raspberrypi3"
 
 RPI_USE_U_BOOT = "1"

--- a/conf/variant/rpi/local.conf.sample
+++ b/conf/variant/rpi/local.conf.sample
@@ -1,5 +1,9 @@
 require conf/variant/common/local.conf
 
+WKS_FILE = "raspberrypi.wks"
+
+IMAGE_FSTYPES_append = " wic wic.bmap wic.bz2"
+
 MACHINE = "raspberrypi3"
 
 RPI_USE_U_BOOT = "1"

--- a/meta-arp-extras/recipes-core/base-files/base-files/fstab
+++ b/meta-arp-extras/recipes-core/base-files/base-files/fstab
@@ -1,5 +1,5 @@
 /dev/root                                       /       auto    defaults        1       1
 PARTUUID=533a0bc2-8de5-11e9-b7c5-4fc76f6948de	/boot	vfat	defaults	0	0
 PARTUUID=5ffda79c-8de5-11e9-b8ca-73b4a02c6760	swap	swap	defaults	0	0
-PARTUUID=88e6de58-8de5-11e9-a034-0be78a518c85   /media  ext4    defaults        0       0
+PARTUUID=88e6de58-8de5-11e9-a034-0be78a518c85   /data   ext4    defaults        0       0
 

--- a/meta-intel-extras/recipes-core/base-files/base-files/intel-corei7-64/fstab
+++ b/meta-intel-extras/recipes-core/base-files/base-files/intel-corei7-64/fstab
@@ -1,4 +1,4 @@
 /dev/root            /                    auto       defaults              1  1
 PARTUUID=279767e4-75b9-4b6b-92ca-cddbe821e3a6	/boot	vfat	defaults	0	0
 PARTUUID=36e409e3-bec6-4d36-9d93-51f917421531	swap	swap	defaults	0	0
-PARTUUID=bb816e8c-8133-11e9-bd41-631d53cbea7e   /media  ext4    defaults	0	0
+PARTUUID=bb816e8c-8133-11e9-bd41-631d53cbea7e   /data   ext4    defaults	0	0

--- a/meta-rpi-extras/recipes-core/base-files/base-files/raspberrypi3/fstab
+++ b/meta-rpi-extras/recipes-core/base-files/base-files/raspberrypi3/fstab
@@ -1,2 +1,1 @@
 /dev/root            /                    auto       defaults              1  1
-/dev/mmcblk0p1       /boot                auto       defaults,sync         0  0

--- a/scripts/lib/wic/canned-wks/mkefidisk-multiboot.wks
+++ b/scripts/lib/wic/canned-wks/mkefidisk-multiboot.wks
@@ -10,6 +10,6 @@ part / --source rootfs --fstype=ext4 --label platform2 --size 2756 --align 1024 
 
 part swap --size 44 --label swap1 --fstype=swap --uuid 36e409e3-bec6-4d36-9d93-51f917421531
 
-part /media --ondisk sda --size 787 --fstype=ext4 --label media --align 1024 --overhead-factor 1.3 --uuid bb816e8c-8133-11e9-bd41-631d53cbea7e
+part /data --ondisk sda --size 787 --fstype=ext4 --label data --align 1024 --overhead-factor 1.3 --uuid bb816e8c-8133-11e9-bd41-631d53cbea7e
 
 bootloader --configfile cfg --ptable gpt --timeout=5 --append="rootfstype=ext4 console=ttyS0,115200 console=tty0"

--- a/scripts/lib/wic/canned-wks/raspberrypi.wks
+++ b/scripts/lib/wic/canned-wks/raspberrypi.wks
@@ -5,3 +5,4 @@
 part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 20
 part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label platform1 --align 4096 --uuid b488d900-9cc0-11e9-8833-cf4cb425a04d
 part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label platform2 --align 4096 --uuid a2d8ad56-9c9e-11e9-afd8-07ffb5f9d79e
+part /data --ondisk mmcblk0 --size 1024 --fstype=ext4 --label data --align 4096 --uuid 79664834-9c9e-11e9-9603-a744b9801557

--- a/scripts/lib/wic/canned-wks/raspberrypi.wks
+++ b/scripts/lib/wic/canned-wks/raspberrypi.wks
@@ -1,0 +1,7 @@
+# short-description: Create Raspberry Pi SD card image
+# long-description: Creates a partitioned SD card image for use with
+# Raspberry Pi. Boot files are located in the first vfat partition.
+
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 20
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label platform1 --align 4096 --uuid b488d900-9cc0-11e9-8833-cf4cb425a04d
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label platform2 --align 4096 --uuid a2d8ad56-9c9e-11e9-afd8-07ffb5f9d79e


### PR DESCRIPTION
A wic image will simplify adding partitions to the image and adding
labels for them.

Since root partitions now have labels, the blacklisting added in
4d4ffbaf125badc31be1af34b70f471c820ad034 will work for RPI as well.

A new partition, /media, was also added for RPI images.

Signed-off-by: Fisnik Hajredini <fhajredini@luxoft.com>