### PR TITLE
qtbase: remove examples for Raspberry Pi

### DIFF
--- a/layers/b2qt/recipes-qt/qt5/qtbase_%.bbappend
+++ b/layers/b2qt/recipes-qt/qt5/qtbase_%.bbappend
@@ -1,5 +1,5 @@
-
-#
 # Remove gbm support if we're building for rpi
-#
 PACKAGECONFIG_remove_rpi = "gbm"
+
+# examples packageconfig is set in meta-raspberrypi
+PACKAGECONFIG_remove_rpi = "examples"


### PR DESCRIPTION
This packageconfig is set by bbpappend in meta-raspberrypi. We do not
need this package in PELUX.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>