### PR TITLE
swupdate: add runtime dependency on blktool

### DIFF
--- a/recipes-swupdate/swupdate/swupdate_%.bbappend
+++ b/recipes-swupdate/swupdate/swupdate_%.bbappend
@@ -5,6 +5,8 @@ SRC_URI += " \
      file://swupdate.service \
      "
 
+RDEPENDS = "blktool"
+
 do_install_append() {
     sed -i -e "s|\$UPDATE_TARGET|${MACHINE}|" ${WORKDIR}/swupdate.service
 


### PR DESCRIPTION
SWUpdate needs blktool to function.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>