### PR TITLE
udev-extraconf: add lsblk dependency

### DIFF
--- a/recipes-core/udev-extraconf/udev-extraconf_%.bbappend
+++ b/recipes-core/udev-extraconf/udev-extraconf_%.bbappend
@@ -5,6 +5,8 @@ SRC_URI +=  "\
     file://pelux-roots.blacklist \
 "
 
+RDEPENDS_${PN}_append = " util-linux-lsblk"
+
 do_install_append() {
     install -m 0644 ${WORKDIR}/pelux-roots.blacklist ${D}${sysconfdir}/udev/mount.blacklist.d
 


### PR DESCRIPTION
lsblk is needed to extract labels and UUID:s from partitions/filesystems when checking if they are blacklisted. See 0001-udev-extraconf-allow-labels-and-UUID-s-in-mount-blac.patch .

lsblk was included before c2ca4d55701096b8710727655e23a7185cf438f2 indirectly through some dependency in tools-testapps .