### PR TITLE
qtwayland: fix config for Raspberry Pi

### DIFF
--- a/layers/b2qt/recipes-qt/qt5/qtwayland/add-wayland-scanner-client-wayland-protocol-include.patch
+++ b/layers/b2qt/recipes-qt/qt5/qtwayland/add-wayland-scanner-client-wayland-protocol-include.patch
@@ -1,0 +1,12 @@
+diff --git a/src/hardwareintegration/client/brcm-egl/brcm-egl.pri b/src/hardwareintegration/client/brcm-egl/brcm-egl.pri
+index f9f8d072..74292783 100644
+--- a/src/hardwareintegration/client/brcm-egl/brcm-egl.pri
++++ b/src/hardwareintegration/client/brcm-egl/brcm-egl.pri
+@@ -1,6 +1,7 @@
+ INCLUDEPATH += $$PWD
+
+ QMAKE_USE += egl wayland-client libdl
++CONFIG += wayland-scanner-client-wayland-protocol-include
+ QT += egl_support-private
+
+ SOURCES += $$PWD/qwaylandbrcmeglintegration.cpp \

--- a/layers/b2qt/recipes-qt/qt5/qtwayland_%.bbappend
+++ b/layers/b2qt/recipes-qt/qt5/qtwayland_%.bbappend
@@ -1,6 +1,10 @@
-#
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI_append_raspberrypi3 = " \
+    file://add-wayland-scanner-client-wayland-protocol-include.patch \
+"
+
 # Make sure we build with support for the broadcom driver if building for rpi
-#
 PACKAGECONFIG_append_rpi = " wayland-brcm "
 
 # Build examples for wayland since they provide a sample compositor which is handy


### PR DESCRIPTION
We use eglfs as a platform plugin to run Neptune 3 UI. Moreover, it
breaks build of QtWayland 5.13 for a reason that is currently not
understood.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>