### PR TITLE
qtivi-mopidy-plugin: rename plugin library

### DIFF
--- a/layers/b2qt/recipes-multimedia/qtivi-mopidy-plugin/qtivi-mopidy-plugin_git.bb
+++ b/layers/b2qt/recipes-multimedia/qtivi-mopidy-plugin/qtivi-mopidy-plugin_git.bb
@@ -16,7 +16,7 @@ inherit qmake5
 
 do_install() {
     install -m 0755 -d ${D}${libdir}/plugins/qtivi/
-    install -m 0644 ${WORKDIR}/build/libmedia_mopidy.so ${D}${libdir}/plugins/qtivi/
+    install -m 0644 ${WORKDIR}/build/libmedia_mopidy.so ${D}${libdir}/plugins/qtivi/libzzmedia_mopidy_experimental.so
 }
 
 FILES_${PN} += "${libdir}/plugins/qtivi/"


### PR DESCRIPTION
Renamed plugin library file to libzzmedia_mopidy_experimental.so, so
it is the last one to be picked by the Qt IVI and to indicate that it
is not production ready.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>