### PR TITLE
pulseaudio: allow anonymous access for UNIX clients

### DIFF
--- a/recipes-multimedia/pulseaudio/pulseaudio/system.pa
+++ b/recipes-multimedia/pulseaudio/pulseaudio/system.pa
@@ -33,7 +33,7 @@ load-module module-esound-protocol-unix
 .ifexists module-native-protocol-tcp.so
 load-module module-native-protocol-tcp auth-ip-acl=127.0.0.1
 .endif
-load-module module-native-protocol-unix
+load-module module-native-protocol-unix auth-anonymous=1
 
 ### Automatically restore the volume of streams and devices
 load-module module-stream-restore


### PR DESCRIPTION
PELUX does not use the user level account and uses pulse level system
level. However, when using system level, a client can not access it
due to the permission problem for unix socket.

Allow anonymous access for local clients.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>