### PR TITLE
udev-extraconf: do not mount swap partitions

### DIFF
--- a/recipes-core/udev-extraconf/udev-extraconf/0001-udev-extraconf-allow-labels-and-UUID-s-in-mount-blac.patch
+++ b/recipes-core/udev-extraconf/udev-extraconf/0001-udev-extraconf-allow-labels-and-UUID-s-in-mount-blac.patch
@@ -1,7 +1,8 @@
-From 1aa8f8af363518578437ac6921754e1e175b6943 Mon Sep 17 00:00:00 2001
+From 5c70ff0bbeed422f44fb977ba5e18b12605e986d Mon Sep 17 00:00:00 2001
 From: Martin Ejdestig <mejdestig@luxoft.com>
 Date: Tue, 25 Jun 2019 15:06:06 +0200
-Subject: [PATCH] udev-extraconf: allow labels and UUID:s in mount blacklists
+Subject: [PATCH 1/2] udev-extraconf: allow labels and UUID:s in mount
+ blacklists
 
 Needed for systems were device nodes are not known when an image is built
 but there are partitions that should not be automatically mounted.
@@ -47,5 +48,5 @@ index 3ee67b1318..f655c7003d 100644
  
  automount_systemd() {
 -- 
-2.22.0
+2.17.1
 

--- a/recipes-core/udev-extraconf/udev-extraconf/0002-udev-extraconf-do-not-try-to-mount-swap-partitions.patch
+++ b/recipes-core/udev-extraconf/udev-extraconf/0002-udev-extraconf-do-not-try-to-mount-swap-partitions.patch
@@ -1,0 +1,33 @@
+From 6939f7af8a369dbd617c2551421588029215ce3a Mon Sep 17 00:00:00 2001
+From: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>
+Date: Fri, 19 Jul 2019 13:42:08 +0200
+Subject: [PATCH 2/2] udev-extraconf: do not try to mount swap partitions
+
+Swap is a special filesystem that cannot be mounted, so do not try to,
+otherwise we will have service that tries and fails to mount it with
+the following error:
+
+systemd[1]: Mounting /run/media/nvme0n1p3...
+mount[1229]: mount: /run/media/nvme0n1p3: unknown filesystem type 'swap'.
+
+Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>
+---
+ meta/recipes-core/udev/udev-extraconf/mount.sh | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/meta/recipes-core/udev/udev-extraconf/mount.sh b/meta/recipes-core/udev/udev-extraconf/mount.sh
+index f655c7003d..3f3bd9ab1b 100644
+--- a/meta/recipes-core/udev/udev-extraconf/mount.sh
++++ b/meta/recipes-core/udev/udev-extraconf/mount.sh
+@@ -62,6 +62,8 @@ automount_systemd() {
+     vfat|fat)
+         MOUNT="$MOUNT -o umask=007,gid=`awk -F':' '/^disk/{print $3}' /etc/group`"
+         ;;
++    swap)
++        ;;
+     # TODO
+     *)
+         ;;
+-- 
+2.17.1
+

--- a/recipes-core/udev-extraconf/udev-extraconf_%.bbappend
+++ b/recipes-core/udev-extraconf/udev-extraconf_%.bbappend
@@ -2,6 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 SRC_URI +=  "\
     file://0001-udev-extraconf-allow-labels-and-UUID-s-in-mount-blac.patch;striplevel=5 \
+    file://0002-udev-extraconf-do-not-try-to-mount-swap-partitions.patch;striplevel=5 \
     file://pelux-roots.blacklist \
 "
 


### PR DESCRIPTION
Skip mounting swap partitions as they have special filesystem that
cannot and should not be mounted.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>