### PR TITLE
Patches to make persistance-administrator daemon run

### DIFF
--- a/recipes-temporary-patches/persistence-administrator/persistence-administrator/0002-Replace-unknown-oip-cpi-mandatory.target-in-systemd-.patch
+++ b/recipes-temporary-patches/persistence-administrator/persistence-administrator/0002-Replace-unknown-oip-cpi-mandatory.target-in-systemd-.patch
@@ -1,0 +1,32 @@
+From 07e19a31d92f716330e0739824f13b62096877d7 Mon Sep 17 00:00:00 2001
+From: Martin Ejdestig <mejdestig@luxoft.com>
+Date: Fri, 19 Jul 2019 11:04:35 +0200
+Subject: [PATCH] Replace unknown oip-cpi-mandatory.target in systemd service
+ file
+
+With a well known systemd target. oip-cpi-mandatory.target is Continental
+specific?
+
+Do not know for sure that multi-user.target is the best one. Perhaps the
+administrator service should be changed to be D-Bus activated in the future
+since it is not required to be running all the time (if I have understood
+things correctly).
+
+Signed-off-by: Martin Ejdestig <mejdestig@luxoft.com>
+---
+ Administrator/config/pas-daemon.service.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Administrator/config/pas-daemon.service.in b/Administrator/config/pas-daemon.service.in
+index 6246ae0..9d42651 100644
+--- a/Administrator/config/pas-daemon.service.in
++++ b/Administrator/config/pas-daemon.service.in
+@@ -16,4 +16,4 @@ StartLimitBurst=3
+ StartLimitAction=reboot
+ 
+ [Install]
+-WantedBy=oip-cpi-mandatory.target
++WantedBy=multi-user.target
+-- 
+2.22.0
+

--- a/recipes-temporary-patches/persistence-administrator/persistence-administrator_%.bbappend
+++ b/recipes-temporary-patches/persistence-administrator/persistence-administrator_%.bbappend
@@ -1,3 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += "file://0001-Make-snprintf-comply-with-Werror-format-security.patch"
+
+# Upstream pr: https://github.com/GENIVI/persistence-administrator/pull/6
+SRC_URI += "file://0002-Replace-unknown-oip-cpi-mandatory.target-in-systemd-.patch"

--- a/recipes-temporary-patches/persistence-client-library/persistence-client-library/0001-Remove-D-Bus-policy-configuration-for-org.genivi.per.patch
+++ b/recipes-temporary-patches/persistence-client-library/persistence-client-library/0001-Remove-D-Bus-policy-configuration-for-org.genivi.per.patch
@@ -1,0 +1,43 @@
+From ca2d3051e3d1ec8fb9abcec2c8e4804136f45862 Mon Sep 17 00:00:00 2001
+From: Martin Ejdestig <mejdestig@luxoft.com>
+Date: Thu, 18 Jul 2019 10:57:47 +0200
+Subject: [PATCH] Remove D-Bus policy configuration for
+ org.genivi.persistence.admin
+
+The policy file is never installed by Makefile and it is
+persistence-common-object that takes the name so policy should probably be
+in that repository. Remove from pcl for less confusion.
+
+See GENIVI/persistence-common-object#8 for more details.
+
+Signed-off-by: Martin Ejdestig <mejdestig@luxoft.com>
+---
+ config/org.genivi.persistence.admin.conf | 16 ----------------
+ 1 file changed, 16 deletions(-)
+ delete mode 100644 config/org.genivi.persistence.admin.conf
+
+diff --git a/config/org.genivi.persistence.admin.conf b/config/org.genivi.persistence.admin.conf
+deleted file mode 100644
+index 4058199..0000000
+--- a/config/org.genivi.persistence.admin.conf
++++ /dev/null
+@@ -1,16 +0,0 @@
+-<!DOCTYPE busconfig PUBLIC
+- "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+- "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+-<busconfig>
+-
+-	<!-- Only root can own the service -->
+-	<policy user="root">
+-		<allow own="org.genivi.persistence.admin"/>
+-		<allow send_destination="org.genivi.persistence.admin"/>
+-		<allow send_interface="org.genivi.persistence.admin"/>
+-	</policy>
+-	<policy context="default">
+-    	<allow send_destination="org.genivi.persistence.admin"/>
+-    	<allow send_interface="org.genivi.persistence.admin"/>
+-  </policy>
+-</busconfig>
+-- 
+2.22.0
+

--- a/recipes-temporary-patches/persistence-client-library/persistence-client-library_%.bbappend
+++ b/recipes-temporary-patches/persistence-client-library/persistence-client-library_%.bbappend
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+# Upstream pr: https://github.com/GENIVI/persistence-client-library/pull/16
+SRC_URI += "file://0001-Remove-D-Bus-policy-configuration-for-org.genivi.per.patch"
+
+# Upstream pr: https://github.com/GENIVI/meta-ivi/pull/111
+RDEPENDS_${PN}_append = " persistence-administrator"

--- a/recipes-temporary-patches/persistence-common-object/persistence-common-object/0002-Revert-dbus_config-Remove-dbus-configuration-file.patch
+++ b/recipes-temporary-patches/persistence-common-object/persistence-common-object/0002-Revert-dbus_config-Remove-dbus-configuration-file.patch
@@ -1,0 +1,76 @@
+From 5a17af16a01a6cbe2cd9e027e75783593a4c5316 Mon Sep 17 00:00:00 2001
+From: Martin Ejdestig <mejdestig@luxoft.com>
+Date: Thu, 18 Jul 2019 10:19:08 +0200
+Subject: [PATCH] Revert "dbus_config: Remove dbus configuration file"
+
+This reverts commit 103be9f0bb77df0b139541ab366ff98a4fe4e408.
+
+No D-Bus policy file is installed which causes persistence-administrator
+to fail during startup since it ends up calling a persitence-client-object
+function that wants to own the name org.genivi.persistence.admin. Owning
+names is denied by default on the system bus.
+
+Since it is persistence-common-object that takes the name
+org.genivi.persistence.admin in src/pers_ipc_dbus.c:persIpcPASLoopThread(),
+the configuration probably belongs in this repository.
+
+It looks like persistence-client-library has never installed
+org.genivi.persistence.admin.conf itself in its build system. It was done
+for a while in meta-ivi which must have been the source of the conflict
+mentioned in the reverted commit. Installed in
+GENIVI/meta-ivi@7318681d851e3e3ee22a but later removed in
+GENIVI/meta-ivi@9d5a45e473fbb3a29f5e with the comment "it should be done
+by PCO".
+
+The reverted commit was sent in pull request #3 with no reasoning as to why
+it should be added by persistent-client-library instead of
+persistence-common-object. Later pull request #5 first adds it but then
+removes it again in a later commit. Unsure why. Reasoning in comment about
+the missing D-Bus config file seemed correct.
+
+Signed-off-by: Martin Ejdestig <mejdestig@luxoft.com>
+---
+ dbus_config/org.genivi.persistence.admin.conf | 16 ++++++++++++++++
+ src/Makefile.am                               |  2 ++
+ 2 files changed, 18 insertions(+)
+ create mode 100644 dbus_config/org.genivi.persistence.admin.conf
+
+diff --git a/dbus_config/org.genivi.persistence.admin.conf b/dbus_config/org.genivi.persistence.admin.conf
+new file mode 100644
+index 0000000..fac05f9
+--- /dev/null
++++ b/dbus_config/org.genivi.persistence.admin.conf
+@@ -0,0 +1,16 @@
++<!DOCTYPE busconfig PUBLIC
++ "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
++ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
++<busconfig>
++
++	<!-- Only root can own the service -->
++	<policy user="root">
++		<allow own="org.genivi.persistence.admin"/>
++		<allow send_destination="org.genivi.persistence.admin"/>
++		<allow send_interface="org.genivi.persistence.admin"/>
++	</policy>
++	<policy context="default">
++    	<allow send_destination="org.genivi.persistence.admin"/>
++    	<allow send_interface="org.genivi.persistence.admin"/>
++  </policy>
++</busconfig>
+\ No newline at end of file
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 2294605..15231bc 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -114,6 +114,8 @@ libpers_common_la_LIBADD += \
+                              $(RAWDB_LIBS)
+ endif
+ 
++dbuspolicy_DATA = ../dbus_config/org.genivi.persistence.admin.conf
++
+ # Export interface description of org.genivi.persistence.admin DBus interface
+ dbusinterfaces_DATA = ../dbus_specifications/org.genivi.persistence.admin.xml
+ 
+-- 
+2.22.0
+

--- a/recipes-temporary-patches/persistence-common-object/persistence-common-object/0003-Install-D-Bus-policy-file-in-usr-share-dbus-1-system.patch
+++ b/recipes-temporary-patches/persistence-common-object/persistence-common-object/0003-Install-D-Bus-policy-file-in-usr-share-dbus-1-system.patch
@@ -1,0 +1,34 @@
+From 95b5e3220516c50ba291f0e931039a9f49e3a214 Mon Sep 17 00:00:00 2001
+From: Martin Ejdestig <mejdestig@luxoft.com>
+Date: Mon, 22 Jul 2019 09:17:38 +0200
+Subject: [PATCH 2/2] Install D-Bus policy file in /usr/share/dbus-1/system.d
+
+Instead of /etc/dbus-1/system.d. Package supplied policy configuration
+in /etc/dbus-1/system.d is officially deprecated in D-Bus since 1.13.10 and
+is reserved for system administrators wanting to override default behavior.
+/usr/share/dbus-1/system.d has been preferred since D-Bus 1.10.0 (released
+~4 years ago). See the following commit in D-Bus for deprecation notice:
+
+https://gitlab.freedesktop.org/dbus/dbus/commit/dee0f551112349da4aa3f913f92f2c7c8f48f1f0
+
+Signed-off-by: Martin Ejdestig <mejdestig@luxoft.com>
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 1bf051c..29d8f67 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -247,7 +247,7 @@ dnl *************************************
+ AC_ARG_WITH([dbuspolicydir],
+         AS_HELP_STRING([--with-dbuspolicydirdir=DIR], [Directory for D-Bus system policy files]),
+         [],
+-        [with_dbuspolicydir=$(pkg-config --silence-errors --variable=sysconfdir dbus-1)/dbus-1/system.d])
++        [with_dbuspolicydir=$(pkg-config --silence-errors --variable=datadir dbus-1)/dbus-1/system.d])
+ AC_SUBST([dbuspolicydir], [$with_dbuspolicydir])
+ 
+ # Derive path for storing 'dbus' interface files (e. g. /usr/share/dbus-1/interfaces)
+-- 
+2.22.0
+

--- a/recipes-temporary-patches/persistence-common-object/persistence-common-object_%.bbappend
+++ b/recipes-temporary-patches/persistence-common-object/persistence-common-object_%.bbappend
@@ -2,3 +2,9 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 # Upstream pr: https://github.com/GENIVI/persistence-common-object/pull/7
 SRC_URI += "file://0001-Partial-revert-of-3b28999fa9a1f7f8cd9b55ba6f8165e244.patch"
+
+# Upstream pr: https://github.com/GENIVI/persistence-common-object/pull/8
+SRC_URI += "\
+    file://0002-Revert-dbus_config-Remove-dbus-configuration-file.patch \
+    file://0003-Install-D-Bus-policy-file-in-usr-share-dbus-1-system.patch \
+"


### PR DESCRIPTION
This commit only makes it so it runs without immediately exiting when trying to start the pas-daemon service. See commit messages in patch files and upstream pull requests for details.

Note: I think we should wait with pulling this into master before we have verified the full pcl vertical. Having this PR makes it easier for others to pick up the persistance-administrator fixes at least.