### PR TITLE
meta-arp-extras: fix wrong UUID:s in /etc/fstab

### DIFF
--- a/meta-arp-extras/recipes-core/base-files/base-files/fstab
+++ b/meta-arp-extras/recipes-core/base-files/base-files/fstab
@@ -1,5 +1,4 @@
-/dev/root                                       /       auto    defaults        1       1
-PARTUUID=533a0bc2-8de5-11e9-b7c5-4fc76f6948de	/boot	vfat	defaults	0	0
-PARTUUID=5ffda79c-8de5-11e9-b8ca-73b4a02c6760	swap	swap	defaults	0	0
-PARTUUID=88e6de58-8de5-11e9-a034-0be78a518c85   /data   ext4    defaults        0       0
-
+/dev/root            /                    auto       defaults              1  1
+PARTUUID=279767e4-75b9-4b6b-92ca-cddbe821e3a6	/boot	vfat	defaults	0	0
+PARTUUID=36e409e3-bec6-4d36-9d93-51f917421531	swap	swap	defaults	0	0
+PARTUUID=bb816e8c-8133-11e9-bd41-631d53cbea7e   /data   ext4    defaults	0	0


### PR DESCRIPTION
Wrong UUID:s added in b5219d7b55ac355474713df5ceb513d63a1ed031.

Will fix this more properly after 4.0 (do not want to break something this close to release). See #348 .