### PR TITLE
connman: add connman-client to rdepends

### DIFF
--- a/recipes-connectivity/connman/connman_%.bbappend
+++ b/recipes-connectivity/connman/connman_%.bbappend
@@ -1,3 +1,5 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += "file://disable_connman_dns_proxy.patch"
+
+RDEPENDS_${PN} += " connman-client"


### PR DESCRIPTION
We need connman-client to work with connman. Add it to its runtime
dependencies, so it is always deployed to images together with connman.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>