### PR TITLE
rpi-config: do not set GPU_MEM

### DIFF
--- a/meta-rpi-extras/recipes-bsp/boot-files/rpi-config_%.bbappend
+++ b/meta-rpi-extras/recipes-bsp/boot-files/rpi-config_%.bbappend
@@ -1,12 +1,3 @@
-
-#
-# Reserve 512MB RAM for the GPU if this is the QtAS variant, otherwise 128MB
-#
-# This checks if the b2qt layer is included.
-#
-
-GPU_MEM="${@bb.utils.contains("BBFILE_COLLECTIONS", "b2qt", 512, 128, d)}"
-
 #
 # This option, together with the kernel serial command line parameter (in
 # commandline.txt) enables serial console from the kernel.


### PR DESCRIPTION
GPU_MEM is set to 256 Mb in meta-boot2qt now and is sufficient to run
Neptune 3 UI, threfore it makes sence to save precious RAM.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>