### PR TITLE
Revert "Cleanup /etc/fstab handling for Intel and ARP"

### DIFF
--- a/conf/variant/arp-qtauto/bblayers.conf.sample
+++ b/conf/variant/arp-qtauto/bblayers.conf.sample
@@ -7,6 +7,7 @@ require conf/variant/common/bblayers-qtauto.conf
 
 BBLAYERS += "\
     ${BSPDIR}/sources/meta-pelux/meta-intel-extras  \
+    ${BSPDIR}/sources/meta-pelux/meta-arp-extras    \
     ${BSPDIR}/sources/meta-intel                    \
     ${BSPDIR}/sources/meta-arp                      \
 "

--- a/conf/variant/arp-qtauto/local.conf.sample
+++ b/conf/variant/arp-qtauto/local.conf.sample
@@ -9,6 +9,7 @@ IMAGE_FSTYPES += "wic wic.bmap wic.bz2"
 PREFERRED_PROVIDER_iasl-native = "iasl-native"
 
 WKS_FILE = "mkefidisk-multiboot.wks"
+WIC_CREATE_EXTRA_ARGS = "--no-fstab-update"
 
 IMAGE_INSTALL_append = " grub-efi"
 

--- a/conf/variant/arp/bblayers.conf.sample
+++ b/conf/variant/arp/bblayers.conf.sample
@@ -6,6 +6,7 @@ require conf/variant/common/bblayers.conf
 
 BBLAYERS += "\
     ${BSPDIR}/sources/meta-pelux/meta-intel-extras  \
+    ${BSPDIR}/sources/meta-pelux/meta-arp-extras    \
     ${BSPDIR}/sources/meta-intel                    \
     ${BSPDIR}/sources/meta-arp                      \
 "

--- a/conf/variant/arp/local.conf.sample
+++ b/conf/variant/arp/local.conf.sample
@@ -9,6 +9,7 @@ EFI_PROVIDER = "grub-efi"
 PREFERRED_PROVIDER_iasl-native = "iasl-native"
 
 WKS_FILE = "mkefidisk-multiboot.wks"
+WIC_CREATE_EXTRA_ARGS = "--no-fstab-update"
 
 IMAGE_INSTALL_append = " grub-efi"
 

--- a/conf/variant/intel-qtauto/local.conf.sample
+++ b/conf/variant/intel-qtauto/local.conf.sample
@@ -9,6 +9,7 @@ EFI_PROVIDER = "grub-efi"
 PREFERRED_PROVIDER_iasl-native = "iasl-native"
 
 WKS_FILE = "mkefidisk-multiboot.wks"
+WIC_CREATE_EXTRA_ARGS = "--no-fstab-update"
 
 IMAGE_INSTALL_append = " grub-efi"
 

--- a/conf/variant/intel/local.conf.sample
+++ b/conf/variant/intel/local.conf.sample
@@ -9,6 +9,7 @@ EFI_PROVIDER = "grub-efi"
 PREFERRED_PROVIDER_iasl-native = "iasl-native"
 
 WKS_FILE = "mkefidisk-multiboot.wks"
+WIC_CREATE_EXTRA_ARGS = "--no-fstab-update"
 
 IMAGE_INSTALL_append = " grub-efi"
 

--- a/meta-arp-extras/conf/layer.conf
+++ b/meta-arp-extras/conf/layer.conf
@@ -1,0 +1,12 @@
+BBPATH .= ":${LAYERDIR}"
+
+# We have a recipes directory, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "pelux-bsp-arp-layer"
+BBFILE_PATTERN_pelux-bsp-arp-layer := "^${LAYERDIR}/"
+
+BBFILE_PRIORITY_pelux-bsp-arp-layer = "10"
+
+LAYERSERIES_COMPAT_pelux-bsp-arp-layer = "sumo thud warrior"
+

--- a/meta-arp-extras/recipes-core/base-files/base-files/fstab
+++ b/meta-arp-extras/recipes-core/base-files/base-files/fstab
@@ -1,0 +1,4 @@
+/dev/root            /                    auto       defaults              1  1
+PARTUUID=279767e4-75b9-4b6b-92ca-cddbe821e3a6	/boot	vfat	defaults	0	0
+PARTUUID=36e409e3-bec6-4d36-9d93-51f917421531	swap	swap	defaults	0	0
+PARTUUID=bb816e8c-8133-11e9-bd41-631d53cbea7e   /data   ext4    defaults	0	0

--- a/meta-arp-extras/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-arp-extras/recipes-core/base-files/base-files_%.bbappend
@@ -1,0 +1,8 @@
+#
+#   Copyright (C) 2019 Luxoft AB
+#   SPDX-License-Identifier: MIT
+#
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+SRC_URI += "file://fstab"
+

--- a/meta-intel-extras/recipes-core/base-files/base-files/intel-corei7-64/fstab
+++ b/meta-intel-extras/recipes-core/base-files/base-files/intel-corei7-64/fstab
@@ -1,0 +1,4 @@
+/dev/root            /                    auto       defaults              1  1
+PARTUUID=279767e4-75b9-4b6b-92ca-cddbe821e3a6	/boot	vfat	defaults	0	0
+PARTUUID=36e409e3-bec6-4d36-9d93-51f917421531	swap	swap	defaults	0	0
+PARTUUID=bb816e8c-8133-11e9-bd41-631d53cbea7e   /data   ext4    defaults	0	0

--- a/meta-intel-extras/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-intel-extras/recipes-core/base-files/base-files_%.bbappend
@@ -1,0 +1,8 @@
+#
+#   Copyright (C) 2017 Pelagicore AB
+#   SPDX-License-Identifier: MIT
+#
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+SRC_URI += "file://fstab"
+

--- a/scripts/lib/wic/canned-wks/mkefidisk-multiboot.wks
+++ b/scripts/lib/wic/canned-wks/mkefidisk-multiboot.wks
@@ -2,14 +2,14 @@
 # long-description: Creates a partitioned EFI disk image that the user
 # can directly dd to boot media.
 
-part /boot --source bootimg-efi --sourceparams="loader=grub-efi" --label msdos --active --align 1024 --use-uuid
+part /boot --source bootimg-efi --sourceparams="loader=grub-efi" --label msdos --active --align 1024 --uuid 279767e4-75b9-4b6b-92ca-cddbe821e3a6
 
-part / --source rootfs --fstype=ext4 --label platform1 --size 2756 --align 1024 --overhead-factor 1.3 --use-uuid --uuid 4f531a2e-d931-4308-8ccd-d2262b910bad
+part / --source rootfs --fstype=ext4 --label platform1 --size 2756 --align 1024 --overhead-factor 1.3 --uuid 4f531a2e-d931-4308-8ccd-d2262b910bad
 
-part / --source rootfs --fstype=ext4 --label platform2 --size 2756 --align 1024 --overhead-factor 1.3 --use-uuid --uuid 12586f0b-38ad-42b8-8340-fe9d08db7139
+part / --source rootfs --fstype=ext4 --label platform2 --size 2756 --align 1024 --overhead-factor 1.3 --uuid 12586f0b-38ad-42b8-8340-fe9d08db7139
 
-part swap --size 44 --label swap1 --fstype=swap --use-uuid
+part swap --size 44 --label swap1 --fstype=swap --uuid 36e409e3-bec6-4d36-9d93-51f917421531
 
-part /data --ondisk sda --size 787 --fstype=ext4 --label data --align 1024 --overhead-factor 1.3 --use-uuid
+part /data --ondisk sda --size 787 --fstype=ext4 --label data --align 1024 --overhead-factor 1.3 --uuid bb816e8c-8133-11e9-bd41-631d53cbea7e
 
 bootloader --configfile cfg --ptable gpt --timeout=5 --append="rootfstype=ext4 console=ttyS0,115200 console=tty0"


### PR DESCRIPTION
This reverts commit 1acf4025a35a630a572d31938ada529951d6c153.

Even though automatically generating fstab from the wks file
is a nice solution, but it does not work well with the swupdate
feature. The reason being that the swupdate swu file does not
contain the fstab file that is generated for wic image. And there
seems to be no way of updating the swu file to contain the fstab
generated by wic script. So the swu file uses the base fstab from
the rpi layer. This results in the partitions mounted incorrectly
when the partition is updated using swupdate. So here we revert
to the solution that uses hard coded fstab files instead.