### PR TITLE
systemd: change to use 'PACKAGECONFIG_append' to add kmod

### DIFF
--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -12,6 +12,4 @@ do_install_append() {
 FILES_${PN} += "/etc/resolv.conf"
 FILES_${PN} += "${sysconfdir}/systemd/system/getty.target.wants"
 
-PACKAGECONFIG += " \
-    kmod \
-"
+PACKAGECONFIG_append = " kmod "


### PR DESCRIPTION
Use 'PACKAGECONFIG +=' to add kmod, will cause systemd package
whole configuration cleared, will remove almost systemd module.

So change to use 'PACKAGECONFIG_append' to add kmod.