### PR TITLE
systemd: stop low-level messages on console

### DIFF
--- a/recipes-core/systemd/systemd/99-printk.conf
+++ b/recipes-core/systemd/systemd/99-printk.conf
@@ -1,0 +1,1 @@
+kernel.printk = 4 4 1 7

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,3 +1,7 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://99-printk.conf"
+
 do_install_append() {
     # Make sure resolv.conf is using systemd-resolved
     ln -s /run/systemd/resolve/resolv.conf ${D}${sysconfdir}/resolv.conf
@@ -11,5 +15,11 @@ do_install_append() {
 
 FILES_${PN} += "/etc/resolv.conf"
 FILES_${PN} += "${sysconfdir}/systemd/system/getty.target.wants"
+FILES_${PN} += "${libdir}/sysctl.d/99-printk.conf"
 
 PACKAGECONFIG_append = " kmod "
+
+do_install_append() {
+    install -d ${D}${libdir}/sysctl.d
+    install -m 0644 ${WORKDIR}/99-printk.conf ${D}${libdir}/sysctl.d/
+}


### PR DESCRIPTION
Lower kernel.printk values to the ones Ubuntu has to get rid of
unnecessary low-level messages.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>