### PR TITLE
core-image-pelux: add iproute2

### DIFF
--- a/classes/core-image-pelux.bbclass
+++ b/classes/core-image-pelux.bbclass
@@ -32,6 +32,7 @@ IMAGE_INSTALL_append = "\
     avs-device-sdk     \
     can-utils \
     connectivity-manager \
+    iproute2 \
     libsocketcan \
     mopidy \
     user-identification-manager \


### PR DESCRIPTION
iproute2 is required to setup CAN devices on Linux.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>