### PR TITLE
pelux.conf: cleanup

### DIFF
--- a/conf/distro/pelux.conf
+++ b/conf/distro/pelux.conf
@@ -17,25 +17,15 @@ TARGET_VENDOR = "-pelux"
 
 # Add distro features
 DISTRO_FEATURES_append = " \
-                          alsa         \
-                          argp         \
-                          bluetooth    \
-                          bluez5       \
-                          largefile    \
-                          multiarch    \
-                          opengl       \
-                          pci          \
-                          pcmcia       \
-                          process-containment \
-                          ptest        \
-                          usbgadget    \
-                          usbhost      \
-                          virtualization \
-                          wayland      \
-                          webengine    \
-                          wifi         \
-                          xattr        \
-                         "
+    bluez5 \
+    multiarch \
+    opengl \
+    process-containment \
+    ptest \
+    virtualization \
+    wayland \
+    webengine\
+"
 
 # Remove unused poky features
 DISTRO_FEATURES_remove = " \


### PR DESCRIPTION
Removed DISTRO_FEATURES that are already part of DISTRO_FEATURES_DEFAULT
variable in oe-core and cleanedup syntax.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>