### PR TITLE
grub: remove disabling execlist support for i915

### DIFF
--- a/scripts/lib/wic/canned-wks/cfg
+++ b/scripts/lib/wic/canned-wks/cfg
@@ -8,9 +8,9 @@ save_env default
 
 # Boot entries
 menuentry 'bootA'{
-    linux /bzImage root=PARTUUID=4f531a2e-d931-4308-8ccd-d2262b910bad rootwait rootfstype=ext4 console=ttyS0,115200 console=tty0 i915.enable_execlists=0
+    linux /bzImage root=PARTUUID=4f531a2e-d931-4308-8ccd-d2262b910bad rootwait rootfstype=ext4 console=ttyS0,115200 console=tty0
 }
 
 menuentry 'bootB'{
-    linux /bzImage root=PARTUUID=12586f0b-38ad-42b8-8340-fe9d08db7139 rootwait rootfstype=ext4 console=ttyS0,115200 console=tty0 i915.enable_execlists=0
+    linux /bzImage root=PARTUUID=12586f0b-38ad-42b8-8340-fe9d08db7139 rootwait rootfstype=ext4 console=ttyS0,115200 console=tty0
 }


### PR DESCRIPTION
This has been added in @e5428651123e47d3c, since the Linux kernel
driver supplied wth Yocto "sumo" 2.5 had an issue that caused it to
crash.

The issue has resolved fixed in newer versions of the driver, so get
rid of this workaround.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>