### PR TITLE
Revert "rpi-config: do not set GPU_MEM"

### DIFF
--- a/meta-rpi-extras/recipes-bsp/boot-files/rpi-config_%.bbappend
+++ b/meta-rpi-extras/recipes-bsp/boot-files/rpi-config_%.bbappend
@@ -1,3 +1,12 @@
+
+#
+# Reserve 512MB RAM for the GPU if this is the QtAS variant, otherwise 128MB
+#
+# This checks if the b2qt layer is included.
+#
+
+GPU_MEM="${@bb.utils.contains("BBFILE_COLLECTIONS", "b2qt", 512, 128, d)}"
+
 #
 # This option, together with the kernel serial command line parameter (in
 # commandline.txt) enables serial console from the kernel.


### PR DESCRIPTION
This has unfortunately led to unstbilities in the Neptune 3 UI work.

This reverts commit c5d9825bd63bca344412bb5aa60f80223897d571.