### PR TITLE
layer.conf: add bc to HOSTTOOLS

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -1,6 +1,6 @@
 #
 #   Copyright (C) 2016-2017 Pelagicore AB
-#   Copyright (C) 2018 Luxoft Sweden AB
+#   Copyright (C) 2019 Luxoft Sweden AB
 #   SPDX-License-Identifier: MIT
 #
 
@@ -24,3 +24,5 @@ BBFILES += "${@' '.join('${LAYERDIR}/layers/%s/recipes*/*/*.bb' % layer \
                for layer in BBFILE_COLLECTIONS.split())}"
 
 LAYERSERIES_COMPAT_pelux-layer = "sumo thud warrior"
+
+HOSTTOOLS += "bc"


### PR DESCRIPTION
bc is required to build kernel and kernel modules with the SDK,
otherwise the following error will occur:

  /bin/sh: 1: bc: not found

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>