### PR TITLE
pelux.conf: add pam to DISTRO_FEATURES

### DIFF
--- a/conf/distro/pelux.conf
+++ b/conf/distro/pelux.conf
@@ -20,6 +20,7 @@ DISTRO_FEATURES_append = " \
     bluez5 \
     multiarch \
     opengl \
+    pam \
     process-containment \
     ptest \
     virtualization \


### PR DESCRIPTION
systemd needs PAM support for user sessions to work correctly,
otherwise XDG_RUNTIME_DIR won't be created on boot and Wayland
will complain[1]:

  [FAILED] Failed to start User Manager for UID 0.

pam packageconfig has been enabled in meta-boot2qt (@ded06350f2dd23b),
and will later be merged to thud and/or warrior branche, but
prerequisite for it is pam DISTRO_FEATURE in Yocto.

[1] https://bugreports.qt.io/browse/QTBUG-75543

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>