### PR TITLE
qdb: disable systemd service

### DIFF
--- a/layers/b2qt/recipes-qt/boot2qt-addons/qdb_%.bbappend
+++ b/layers/b2qt/recipes-qt/boot2qt-addons/qdb_%.bbappend
@@ -1,0 +1,1 @@
+SYSTEMD_AUTO_ENABLE = "disable"


### PR DESCRIPTION
Qt Debug Bridge (qdb) is part of the following package groups defined
in meta-boot2qt:
- packagegroup-b2qt-automotive-addons
- packagegroup-b2qt-embedded-addons

There is no need in having this service running on PELUX images by
default. According to `systemd-analyze blame`, it takes ~3.5 seconds to
initialize it on Intel NUC:

  3.491s qdbd.service

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>