### PR TITLE
thermald: disable systemd service

### DIFF
--- a/meta-intel-extras/recipes-bsp/thermald/thermald_%.bbappend
+++ b/meta-intel-extras/recipes-bsp/thermald/thermald_%.bbappend
@@ -1,0 +1,1 @@
+SYSTEMD_AUTO_ENABLE = "disable"


### PR DESCRIPTION
thermald comes with BSP package in meta-intel and although its zero
configuration mode is normally sufficient for most systems, there is
currently no need in any thermal control.

Also, due to the lack of configuration supplied, it produces a bunch
of errors, flooding the systemd log:

  sensor id 6 : No temp sysfs for reading raw temp
  sensor id 6 : No temp sysfs for reading raw temp
  sensor id 6 : No temp sysfs for reading raw temp
  I/O warning :
    failed to load external entity "/etc/thermald/thermal-conf.xml"
  error: could not parse file /etc/thermald/thermal-conf.xml
  sysfs open failed
  I/O warning :
    failed to load external entity "/etc/thermald/thermal-conf.xml"
  error: could not parse file /etc/thermald/thermal-conf.xml
  I/O warning :
    failed to load external entity "/etc/thermald/thermal-conf.xml"
  error: could not parse file /etc/thermald/thermal-conf.xml

According to systemd-analyze blame, it takes ~2.5 seconds to initialize
it on Intel NUC:

  2.366s thermald.service

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>