### PR TITLE
linux-intel: disable CONFIG_BTRFS_FS

### DIFF
--- a/meta-intel-extras/recipes-kernel/linux/files/disable-brtfs.cfg
+++ b/meta-intel-extras/recipes-kernel/linux/files/disable-brtfs.cfg
@@ -1,0 +1,1 @@
+CONFIG_BTRFS_FS=n

--- a/meta-intel-extras/recipes-kernel/linux/linux-intel_%.bbappend
+++ b/meta-intel-extras/recipes-kernel/linux/linux-intel_%.bbappend
@@ -12,4 +12,5 @@ SRC_URI += " \
     file://enable-can.cfg \
     file://enable-veth.cfg \
     file://enable-hid-multitouch.cfg \
+    file://disable-brtfs.cfg \
 "


### PR DESCRIPTION
During boot, kernel spends around 200ms executing raid6_select_algo()
function.

RAID6 is selected by CONFIG_BTRFS_FS, neither of which we do not need.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>