### PR TITLE
grub-efi: strip unnecessary modules

### DIFF
--- a/meta-intel-extras/recipes-support/grub/grub-efi_%.bbappend
+++ b/meta-intel-extras/recipes-support/grub/grub-efi_%.bbappend
@@ -25,3 +25,5 @@ FILES_${PN} += " \
 "
 
 SYSTEMD_SERVICE_${PN} = "grubenv-copy.service"
+
+GRUB_BUILDIN = "boot linux fat part_gpt normal efi_gop loadenv"


### PR DESCRIPTION
grub is by default built with the following modules: boot, linux, ext2,
fat, serial, part_msdos, part_gpt, normal, efi_gop, iso9660, configfile,
search, loadenv, test.

Many of those modules are not needed neither for PELUX, neither for a
typical embedded Linux/IVI system.

Build grub-efi with necessary modules only to reduce binary size and
threfore boot time.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>