### PR TITLE
mopidy: run service as mopidy user

### DIFF
--- a/recipes-multimedia/mopidy/mopidy/mopidy.service
+++ b/recipes-multimedia/mopidy/mopidy/mopidy.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Mopidy media service
+User=mopidy
+Group=mopidy
  
 [Install]
 WantedBy=multi-user.target

--- a/recipes-multimedia/mopidy/mopidy_2.2.3.bb
+++ b/recipes-multimedia/mopidy/mopidy_2.2.3.bb
@@ -12,8 +12,7 @@ SRC_URI += "\
     file://mopidy.service \
     "
 
-PYPI_PACKAGE = "Mopidy"
-inherit pypi setuptools systemd
+inherit pypi setuptools systemd useradd
 
 do_install_append() {
     install -d ${D}/${ROOT_HOME}/Music
@@ -43,5 +42,14 @@ FILES_${PN} += " \
     ${ROOT_HOME}/Music \
     ${systemd_system_unitdir}/mopidy.service \
     "
+
+PYPI_PACKAGE = "Mopidy"
+
+# Create user and group
+USER = "mopidy"
+GROUP = "mopidy"
+USERADD_PACKAGES = "${PN}"
+USERADD_PARAM_${PN} = "--no-create-home --gid ${GROUP} --shell /bin/false ${USER}"
+GROUPADD_PARAM_${PN} = "${GROUP}"
 
 SYSTEMD_SERVICE_${PN} = "mopidy.service"


### PR DESCRIPTION
Create mopidy user and group and run systemd service as with those
permissions.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>