### PR TITLE
variant/smarcimx8m: bbmask connman append from meta-fsl-bsp-release

### DIFF
--- a/conf/variant/smarcimx8m/local.conf.sample
+++ b/conf/variant/smarcimx8m/local.conf.sample
@@ -18,3 +18,5 @@ LICENSE_FLAGS_WHITELIST = "commercial_faad2"
 
 # networkmanager conflicts with connman
 MACHINE_EXTRA_RDEPENDS_remove = "networkmanager"
+
+BBMASK .= "|./meta-fsl-bsp-release/imx/meta-bsp/recipes-connectivity/connman/connman_%.bbappend"


### PR DESCRIPTION
meta-fsl-bsp-release has bbappend for connman that supplies some
enhanced verison of connman script with an aim to fix few issues, e.g.
"issue that 2 Ethernet port board failed to mount nfs rootfs" that
are of no concern for us.

Mask this bbappend, so it doesn't conflict with bbappend in meta-pelux.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>