### PR TITLE
qtbase: add eglfs packageconfig for smarcimx8m

### DIFF
--- a/meta-smarcimx8m-extras/recipes-qt/qt5/qtbase_git.bbappend
+++ b/meta-smarcimx8m-extras/recipes-qt/qt5/qtbase_git.bbappend
@@ -1,0 +1,1 @@
+PACAGECONFIG_append = " eglfs "


### PR DESCRIPTION
eglfs packageconfig is not enabled when Freescale SDK is used.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>