### PR TITLE
variant/jetson-tx2: add configuration

### DIFF
--- a/conf/variant/jetson-tx2/README
+++ b/conf/variant/jetson-tx2/README
@@ -1,0 +1,1 @@
+Variant configuration for building a non-graphical PELUX for the NVIDIA Jetson TX2.

--- a/conf/variant/jetson-tx2/bblayers.conf.sample
+++ b/conf/variant/jetson-tx2/bblayers.conf.sample
@@ -1,0 +1,9 @@
+# This is needed for bitbake to pick up the includes
+BSPDIR := "${TOPDIR}/.."
+BBPATH := "${TOPDIR}:${BSPDIR}/sources/meta-pelux"
+
+require conf/variant/common/bblayers.conf
+
+BBLAYERS += "\
+    ${BSPDIR}/sources/meta-tegra \
+"

--- a/conf/variant/jetson-tx2/conf-notes.txt
+++ b/conf/variant/jetson-tx2/conf-notes.txt
@@ -1,0 +1,7 @@
+Available PELUX images for jetson-tx2:
+* core-image-pelux-minimal
+* core-image-pelux-minimal-dev
+* core-image-pelux-minimal-update
+* core-image-pelux-minimal-dev-update
+
+Build them by running: bitbake <image>

--- a/conf/variant/jetson-tx2/local.conf.sample
+++ b/conf/variant/jetson-tx2/local.conf.sample
@@ -1,0 +1,3 @@
+require conf/variant/common/local.conf
+
+MACHINE = "jetson-tx2"


### PR DESCRIPTION
Added cofiguration for minimal image for NVIDIA Jetson TX2.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>