### PR TITLE
avs-device-sdk: build without snowboy for jetson-tx2

### DIFF
--- a/meta-tegra-extras/recipes-alexa/avs-device-sdk/avs-device-sdk_%.bbappend
+++ b/meta-tegra-extras/recipes-alexa/avs-device-sdk/avs-device-sdk_%.bbappend
@@ -1,0 +1,3 @@
+# build without snowboy support since build fails with
+# the aarch64 binaries it provides
+PACKAGECONFIG_remove = " kittai "


### PR DESCRIPTION
Snowboy provides aarch64 binary of its library for two variants:
- aarch64-ubuntu1604
- android/armv8-aarch64

Unfortunately, linker fails to recognize their format and therefore
package build fails on Yocto/PELUX for aarch64.

Build avs-device-sdk without snowboy support for now.

A similar fix was implemented for smarcimx8m (see @8f1634dbfd167d99e).

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>