### PR TITLE
variant/smarcimx8m: remove wrong PREFERED_PROVIDER for u-boot

### DIFF
--- a/conf/variant/smarcimx8m-qtauto/local.conf.sample
+++ b/conf/variant/smarcimx8m-qtauto/local.conf.sample
@@ -2,15 +2,6 @@ require conf/variant/common/local.conf
 
 MACHINE = "smarcimx8m2g"
 
-PREFERRED_PROVIDER_iasl-native = "iasl-native"
-PREFERRED_PROVIDER_libubootenv = "u-boot-fw-utils"
-PREFERRED_PROVIDER_libubootenv-cross = "u-boot-fw-utils"
-PREFERRED_PROVIDER_u-boot-fslc-fw-utils = "u-boot-fw-utils"
-PREFERRED_PROVIDER_u-boot-fslc-fw-utils-cross = "u-boot-fw-utils"
-PREFERRED_PROVIDER_u-boot-fw-utils = "u-boot-fw-utils"
-PREFERRED_PROVIDER_u-boot-qoriq-fw-utils = "u-boot-fw-utils"
-PREFERRED_PROVIDER_u-boot-qoriq-fw-utils-cross = "u-boot-fw-utils"
-
 LICENSE_FLAGS_WHITELIST = "commercial_faad2"
 
 # In order to accept Freescale EULA, uncomment the following line:

--- a/conf/variant/smarcimx8m/local.conf.sample
+++ b/conf/variant/smarcimx8m/local.conf.sample
@@ -2,15 +2,6 @@ require conf/variant/common/local.conf
 
 MACHINE = "smarcimx8m2g"
 
-PREFERRED_PROVIDER_iasl-native = "iasl-native"
-PREFERRED_PROVIDER_libubootenv = "u-boot-fw-utils"
-PREFERRED_PROVIDER_libubootenv-cross = "u-boot-fw-utils"
-PREFERRED_PROVIDER_u-boot-fslc-fw-utils = "u-boot-fw-utils"
-PREFERRED_PROVIDER_u-boot-fslc-fw-utils-cross = "u-boot-fw-utils"
-PREFERRED_PROVIDER_u-boot-fw-utils = "u-boot-fw-utils"
-PREFERRED_PROVIDER_u-boot-qoriq-fw-utils = "u-boot-fw-utils"
-PREFERRED_PROVIDER_u-boot-qoriq-fw-utils-cross = "u-boot-fw-utils"
-
 LICENSE_FLAGS_WHITELIST = "commercial_faad2"
 
 # In order to accept Freescale EULA, uncomment the following line:


### PR DESCRIPTION
Those PREFERRED_PROVIDER for u-boot are wrong. The correct ones are set
in machine config in meta-smarcimx8m.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>