### PR TITLE
jetson-tx2-qtauto: add configuration

### DIFF
--- a/conf/variant/jetson-tx2-qtauto/README
+++ b/conf/variant/jetson-tx2-qtauto/README
@@ -1,0 +1,2 @@
+Variant configuration for building PELUX for the NVIDIA Jetson TX2 with Qt,
+Qt Automotive Suite and Neptune 3 UI.

--- a/conf/variant/jetson-tx2-qtauto/bblayers.conf.sample
+++ b/conf/variant/jetson-tx2-qtauto/bblayers.conf.sample
@@ -1,0 +1,12 @@
+# This is needed for bitbake to pick up the includes
+BSPDIR := "${TOPDIR}/.."
+BBPATH := "${TOPDIR}:${BSPDIR}/sources/meta-pelux"
+
+require conf/variant/common/bblayers.conf
+require conf/variant/common/bblayers-qtauto.conf
+
+BBLAYERS += "\
+    ${BSPDIR}/sources/meta-tegra \
+    ${BSPDIR}/sources/meta-pelux/meta-tegra-extras \
+    ${BSPDIR}/sources/meta-boot2qt/meta-tegra-extras \
+"

--- a/conf/variant/jetson-tx2-qtauto/conf-notes.txt
+++ b/conf/variant/jetson-tx2-qtauto/conf-notes.txt
@@ -1,0 +1,12 @@
+Available PELUX images for jetson-tx2-qtauto:
+* core-image-pelux-minimal
+* core-image-pelux-minimal-dev
+* core-image-pelux-minimal-update
+* core-image-pelux-minimal-dev-update
+
+* core-image-pelux-qtauto-neptune
+* core-image-pelux-qtauto-neptune-dev
+* core-image-pelux-qtauto-neptune-update
+* core-image-pelux-qtauto-neptune-dev-update
+
+Build them by running: bitbake <image>

--- a/conf/variant/jetson-tx2-qtauto/local.conf.sample
+++ b/conf/variant/jetson-tx2-qtauto/local.conf.sample
@@ -1,0 +1,5 @@
+require conf/variant/common/local.conf
+
+MACHINE = "jetson-tx2"
+
+LICENSE_FLAGS_WHITELIST = "commercial_faad2"


### PR DESCRIPTION
Added cofiguration for Qt Auto + Neptune 3 UI variant for NVIDIA
Jetson TX2.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>