### PR TITLE
variant/jetson-tx: mask vulkan append from meta-tegra

### DIFF
--- a/conf/variant/jetson-tx2-qtauto/local.conf.sample
+++ b/conf/variant/jetson-tx2-qtauto/local.conf.sample
@@ -3,3 +3,5 @@ require conf/variant/common/local.conf
 MACHINE = "jetson-tx2"
 
 LICENSE_FLAGS_WHITELIST = "commercial_faad2"
+
+BBMASK .= "./meta-tegra/recipes-graphics/vulkan/vulkan_1.1.73.0.bbappend"

--- a/conf/variant/jetson-tx2/local.conf.sample
+++ b/conf/variant/jetson-tx2/local.conf.sample
@@ -1,3 +1,5 @@
 require conf/variant/common/local.conf
 
 MACHINE = "jetson-tx2"
+
+BBMASK .= "./meta-tegra/recipes-graphics/vulkan/vulkan_1.1.73.0.bbappend"


### PR DESCRIPTION
Nothing currently gets use out of Vulkan in PELUX, but the bbappend in
meta-tegra pulls x11 DISTRO_FEATURE dependency through setting runtime
dependency on libxcb and libxcb-glx0.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>