### PR TITLE
variant/jetson-tx2: generate tegraflash images

### DIFF
--- a/conf/variant/jetson-tx2-qtauto/local.conf.sample
+++ b/conf/variant/jetson-tx2-qtauto/local.conf.sample
@@ -2,6 +2,9 @@ require conf/variant/common/local.conf
 
 MACHINE = "jetson-tx2"
 
+IMAGE_CLASSES += "image_types_tegra"
+IMAGE_FSTYPES += "tegraflash"
+
 LICENSE_FLAGS_WHITELIST = "commercial_faad2"
 
 BBMASK .= "./meta-tegra/recipes-graphics/vulkan/vulkan_1.1.73.0.bbappend"

--- a/conf/variant/jetson-tx2/local.conf.sample
+++ b/conf/variant/jetson-tx2/local.conf.sample
@@ -2,4 +2,7 @@ require conf/variant/common/local.conf
 
 MACHINE = "jetson-tx2"
 
+IMAGE_CLASSES += "image_types_tegra"
+IMAGE_FSTYPES += "tegraflash"
+
 BBMASK .= "./meta-tegra/recipes-graphics/vulkan/vulkan_1.1.73.0.bbappend"


### PR DESCRIPTION
tegraflash is an IMAGE_TYPES defined in meta-tegra that produces set of
artifacts together with dotflash.sh scripts that can be used to flash
a system on Jetson TX boards.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>