### PR TITLE
systemd: use getty-generator for vconsole instantiatiation

### DIFF
--- a/conf/variant/common/local.conf
+++ b/conf/variant/common/local.conf
@@ -28,6 +28,3 @@ NOISO = "1"
 # Removing tar.bz2 image format as it is not used.
 # If needed it can be supplied through own local.conf
 IMAGE_FSTYPES_remove = "tar.bz2"
-
-# List of ttys
-TTY_LIST = "tty2 tty3 tty4 tty5"

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -5,18 +5,10 @@ SRC_URI += "file://99-printk.conf"
 do_install_append() {
     # Make sure resolv.conf is using systemd-resolved
     ln -s /run/systemd/resolve/resolv.conf ${D}${sysconfdir}/resolv.conf
-
-    # Create mutiple consoles
-    tmp="${TTY_LIST}"
-    for ttydev in $tmp ; do
-        ln -sf ${systemd_unitdir}/system/getty@.service \
-            ${D}${sysconfdir}/systemd/system/getty.target.wants/getty@$ttydev.service
-    done
 }
 
 FILES_${PN} += " \
     ${sysconfdir}/resolv.conf \
-    ${sysconfdir}/systemd/system/getty.target.wants \
     ${libdir}/sysctl.d/99-printk.conf \
 "
 


### PR DESCRIPTION
systemd has a native feature that allows generation and instantiatiation
of serial-getty@.service instances for virtualizer consoles.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>