### PR TITLE
psplash: add systemd unit files

### DIFF
--- a/recipes-core/psplash/psplash/psplash-start.service
+++ b/recipes-core/psplash/psplash/psplash-start.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Start Psplash Boot Screen
+Wants=systemd-vconsole-setup.service
+After=systemd-vconsole-setup.service systemd-udev-trigger.service systemd-udevd.service
+DefaultDependencies=no
+
+[Service]
+ExecStart=/usr/bin/psplash --angle 270
+
+[Install]
+WantedBy=sysinit.target

--- a/recipes-core/psplash/psplash/psplash-stop.service
+++ b/recipes-core/psplash/psplash/psplash-stop.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Terminate Psplash Boot Screen
+After=neptune.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/psplash-write QUIT
+TimeoutSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-core/psplash/psplash_%.bbappend
+++ b/recipes-core/psplash/psplash_%.bbappend
@@ -1,0 +1,17 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += " \
+    file://psplash-start.service \
+    file://psplash-stop.service \
+"
+
+inherit systemd
+
+SYSTEMD_PACKAGES = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', '${PN}', '', d)}"
+SYSTEMD_SERVICE_${PN}_append = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', ' psplash-start.service psplash-stop.service', '', d)}"
+
+do_install_append () {
+    install -d ${D}${systemd_system_unitdir}
+    install -m 644 ${WORKDIR}/psplash-start.service ${D}${systemd_system_unitdir}
+    install -m 644 ${WORKDIR}/psplash-stop.service ${D}${systemd_system_unitdir}
+}


### PR DESCRIPTION
Added unit files for two services:
- psplash-start that will start psplash on system boot
- psplash-stop that will stop it right after Neptune 3 UI is started,
  when user switches virtual consoles, user prompt is shown instead of
  the splash screen.

At the moment, default OpenEmbedded screen is shown.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>