### PR TITLE
swupdate: disable systemd service

### DIFF
--- a/recipes-swupdate/swupdate/swupdate_%.bbappend
+++ b/recipes-swupdate/swupdate/swupdate_%.bbappend
@@ -19,3 +19,5 @@ do_install_append() {
 }
 
 SYSTEMD_SERVICE_${PN}_remove = "swupdate-usb@.service swupdate-progress.service"
+
+SYSTEMD_AUTO_ENABLE_${PN} = "disable"


### PR DESCRIPTION
swupdate is currently configured to use one of the local development
workstation as a server which is not always available.

Moreover, we do not want swupdate to check for any updates on start, as
it is more of a proof of concept than a production ready solution, so
disable the corresponding systemd service by default.

It was once disabled in 73c3163ef5, but was later reenabled in
6f7e4f29e6.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>