### PR TITLE
core-image-pelux-qtauto add egl-wayland for jetson-tx2

### DIFF
--- a/classes/core-image-pelux-qtauto.bbclass
+++ b/classes/core-image-pelux-qtauto.bbclass
@@ -22,5 +22,9 @@ IMAGE_INSTALL += " \
 	${@bb.utils.contains("BBFILE_COLLECTIONS", "b2qt", "${QTAUTO_COMPONENTS}", "", d)} \
 "
 
+IMAGE_INSTALL_append_jetson-tx2 = " \
+    egl-wayland \
+"
+
 TOOLCHAIN_HOST_TASK += " nativesdk-packagegroup-b2qt-automotive-qt5-toolchain-host "
 TOOLCHAIN_TARGET_TASK += " packagegroup-b2qt-automotive-qt5-toolchain-target qtapplicationmanager-staticdev"


### PR DESCRIPTION
Added egl-wayland wayland package for Jetson TX2 that contains the
Wayland EGL External Platform library which implements hardware
specific EGL External Platform Interface for the NVIDIA Jetson boards.

Additional info:
https://github.com/NVIDIA/egl-wayland
https://github.com/NVIDIA/eglexternalplatform

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>