### PR TITLE
variant/smarcimx8m-qtauto: mask psplash append

### DIFF
--- a/conf/variant/smarcimx8m-qtauto/local.conf.sample
+++ b/conf/variant/smarcimx8m-qtauto/local.conf.sample
@@ -10,4 +10,5 @@ LICENSE_FLAGS_WHITELIST = "commercial_faad2"
 # networkmanager conflicts with connman
 MACHINE_EXTRA_RDEPENDS_remove = "networkmanager"
 
-BBMASK .= "|./meta-fsl-bsp-release/imx/meta-bsp/recipes-connectivity/connman/connman_%.bbappend"
+BBMASK = "meta-fsl-bsp-release/imx/meta-bsp/recipes-connectivity/connman/"
+BBMASK += "/meta-smarcimx8m/recipes-core/psplash/"


### PR DESCRIPTION
meta-fsl-bsp-release contains psplash patches that conflict with the
ones in meta-pelux layer.

PELUX ships with its own bootsplash for psplash.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>