### PR TITLE
dnsmasq: disable systemd service

### DIFF
--- a/recipes-support/dnsmasq/dnsmasq_%.bbappend
+++ b/recipes-support/dnsmasq/dnsmasq_%.bbappend
@@ -1,0 +1,1 @@
+SYSTEMD_AUTO_ENABLE_${PN} = "disable"


### PR DESCRIPTION
This bbappend has been moved here from meta-bistro (19124921a6).

dnsmasq is a runtime dependency of lxc, but is not needed for PELUX.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>