### PR TITLE
variant/arp-intel: remove meta-intel-extras from bblayers

### DIFF
--- a/conf/variant/arp-intel-qtauto/bblayers.conf.sample
+++ b/conf/variant/arp-intel-qtauto/bblayers.conf.sample
@@ -6,7 +6,6 @@ require conf/variant/common/bblayers.conf
 require conf/variant/common/bblayers-qtauto.conf
 
 BBLAYERS += "\
-    ${BSPDIR}/sources/meta-pelux/meta-intel-extras  \
     ${BSPDIR}/sources/meta-pelux/meta-arp-extras    \
     ${BSPDIR}/sources/meta-intel                    \
     ${BSPDIR}/sources/meta-arp                      \

--- a/conf/variant/arp-intel/bblayers.conf.sample
+++ b/conf/variant/arp-intel/bblayers.conf.sample
@@ -5,7 +5,6 @@ BBPATH := "${TOPDIR}:${BSPDIR}/sources/meta-pelux"
 require conf/variant/common/bblayers.conf
 
 BBLAYERS += "\
-    ${BSPDIR}/sources/meta-pelux/meta-intel-extras  \
     ${BSPDIR}/sources/meta-pelux/meta-arp-extras    \
     ${BSPDIR}/sources/meta-intel                    \
     ${BSPDIR}/sources/meta-arp                      \


### PR DESCRIPTION
Since meta-intel-extras has been removed and its bbappends were moved
to dynamic-layers/intel, remove the meta-layer from bblayers.conf for
the ARP Intel variants.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>