### PR TITLE
variant/arp-intel: remove unnecessary machine conf inclusion

### DIFF
--- a/conf/variant/arp-intel-qtauto/local.conf.sample
+++ b/conf/variant/arp-intel-qtauto/local.conf.sample
@@ -1,5 +1,4 @@
 require conf/variant/common/local.conf
-require conf/machine/intel-corei7-64.conf
 
 MACHINE = "intel-corei7-64"
 

--- a/conf/variant/arp-intel/local.conf.sample
+++ b/conf/variant/arp-intel/local.conf.sample
@@ -1,5 +1,4 @@
 require conf/variant/common/local.conf
-require conf/machine/intel-corei7-64.conf
 
 MACHINE = "intel-corei7-64"
 


### PR DESCRIPTION
Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>