### PR TITLE
variant/jetson-tx2: install kernel-modules

### DIFF
--- a/conf/variant/jetson-tx2-qtauto/local.conf.sample
+++ b/conf/variant/jetson-tx2-qtauto/local.conf.sample
@@ -8,3 +8,7 @@ IMAGE_FSTYPES += "tegraflash"
 LICENSE_FLAGS_WHITELIST = "commercial_faad2"
 
 BBMASK .= "./meta-tegra/recipes-graphics/vulkan/vulkan_1.1.73.0.bbappend"
+
+IMAGE_INSTALL_append = " \
+    kernel-modules \
+"

--- a/conf/variant/jetson-tx2/local.conf.sample
+++ b/conf/variant/jetson-tx2/local.conf.sample
@@ -6,3 +6,7 @@ IMAGE_CLASSES += "image_types_tegra"
 IMAGE_FSTYPES += "tegraflash"
 
 BBMASK .= "./meta-tegra/recipes-graphics/vulkan/vulkan_1.1.73.0.bbappend"
+
+IMAGE_INSTALL_append = " \
+    kernel-modules \
+"


### PR DESCRIPTION
Kernel modules are not shipped for some reason, but do contain a lot of
the essential drivers, e.g. PCI-Express.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>