### PR TITLE
qtapplicationmanager: do not run apps in container on Jetson TX2

### DIFF
--- a/dynamic-layers/b2qt/recipes-qt/automotive/qtapplicationmanager-sc.inc
+++ b/dynamic-layers/b2qt/recipes-qt/automotive/qtapplicationmanager-sc.inc
@@ -18,6 +18,13 @@ SRC_URI += "\
     file://sc-config.yaml \
 "
 
+# softwarecontainer is not configured for Jetson TX2 at the moment,
+# so do not run the Calendar and Map apps inside the container
+do_install_prepend_tegra186() {
+    sed -i '/com.pelagicore.calendar/d' ${WORKDIR}/sc-config.yaml
+    sed -i '/com.pelagicore.map/d' ${WORKDIR}/sc-config.yaml
+}
+
 do_install_append_class-target() {
     install -d ${D}${libdir}
     install -m 755 ${B}/examples/applicationmanager/softwarecontainer-plugin/libsoftwarecontainer-plugin.so ${D}${libdir}


### PR DESCRIPTION
Currently shipped configuration file for the softwarecontainer is
platform specific and does not work on Jetson TX2, so do not run
Neptune apps inside softwarecontainer for now, until a separate
config is provided.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>