### PR TITLE
layer.conf: add smarcimx8m dynamic layer

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -22,6 +22,8 @@ BBFILES_DYNAMIC += " \
     intel:${LAYERDIR}/dynamic-layers/intel/*/*/*.bbappend \
     raspberrypi:${LAYERDIR}/dynamic-layers/raspberrypi/*/*/*.bb \
     raspberrypi:${LAYERDIR}/dynamic-layers/raspberrypi/*/*/*.bbappend \
+    smarcimx8m:${LAYERDIR}/dynamic-layers/smarcimx8m/*/*/*.bb \
+    smarcimx8m:${LAYERDIR}/dynamic-layers/smarcimx8m/*/*/*.bbappend \
     tegra:${LAYERDIR}/dynamic-layers/tegra/*/*/*.bb \
     tegra:${LAYERDIR}/dynamic-layers/tegra/*/*/*.bbappend \
     template-layer:${LAYERDIR}/dynamic-layers/template-layer/*/*/*.bb \


### PR DESCRIPTION
In dedea8cf05 the only bbappend for the meta-smarcimx8m was moved to
dynamics-layers folder, but path to it was not added to layer.conf.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>