### PR TITLE
packagegroup-qt5-toolchain-target: remove qtwebkit-dev from rdepends

### DIFF
--- a/dynamic-layers/smarcimx8m/recipes-qt/qt5/packagegroup-qt5-toolchain-target.bbappend
+++ b/dynamic-layers/smarcimx8m/recipes-qt/qt5/packagegroup-qt5-toolchain-target.bbappend
@@ -1,0 +1,3 @@
+RDEPENDS_${PN}_remove = " \
+    qtwebkit-dev \
+"


### PR DESCRIPTION
For whatever reason, qtwebkit-dev is pulled in through this runtime
dependency. Unfortunately, package does not build due to not being able
to find X11/Xlib.h header, even though it is built without x11 support.

qtwebkit is anyway deprecated and Neptune 3 UI uses QtWebEngine instead
for a web-browser.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>