### PR TITLE
Fixed typo in qtbase for the smarcimx8m

### DIFF
--- a/dynamic-layers/smarcimx8m/recipes-qt/qt5/qtbase_git.bbappend
+++ b/dynamic-layers/smarcimx8m/recipes-qt/qt5/qtbase_git.bbappend
@@ -1,1 +1,1 @@
-PACAGECONFIG_append = " eglfs "
+PACKAGECONFIG_append = " eglfs "


### PR DESCRIPTION
Fixed a typo in the qtbase recipe for the smarcimx8m.

```dynamic-layers/smarcimx8m/recipes-qt/qt5/qtbase_git.bbappend```

Signed-off-by: Dimitris Tassopoulos <dimtass@gmail.com>