### PR TITLE
qtapplicationmanager-sc.inc: Replace += with _append

### DIFF
--- a/dynamic-layers/b2qt/recipes-qt/automotive/qtapplicationmanager-sc.inc
+++ b/dynamic-layers/b2qt/recipes-qt/automotive/qtapplicationmanager-sc.inc
@@ -4,17 +4,17 @@
 #   SPDX-License-Identifier: MIT
 #
 
-RDEPENDS_${PN} += "${PN}-softwarecontainer"
+RDEPENDS_${PN}_append = " ${PN}-softwarecontainer"
 
 # Due to immediate expansion of variables using :=, ${PN} is not yet available
 # in this .inc-file
 FILESEXTRAPATHS_prepend := "${THISDIR}/qtapplicationmanager:"
 
-EXTRA_QMAKEVARS_PRE += "\
+EXTRA_QMAKEVARS_PRE_append = " \
     -config enable-examples \
 "
 
-SRC_URI += "\
+SRC_URI_append = " \
     file://sc-config.yaml \
 "
 


### PR DESCRIPTION
If using += the behaviour is not defined in case the variable
hasn't been set before bitbake parses this line. There is a risk
that the variable is (re)set in the main recipe if _append is
not used.

Signed-off-by: Johan Ederonn <jederonn@luxoft.com>