### PR TITLE
mopidy: bump to 2.3.1

### DIFF
--- a/recipes-multimedia/mopidy/mopidy_2.3.1.bb
+++ b/recipes-multimedia/mopidy/mopidy_2.3.1.bb
@@ -3,8 +3,8 @@ HOMEPAGE = "https://www.mopidy.com/"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
-SRC_URI[md5sum] = "e791afa0e4a1926963433c8c5f3be63b"
-SRC_URI[sha256sum] = "361913efcb97afc18752d1ebce688f120955a19dae2e9a2b5c29aa6d20044fbf"
+SRC_URI[md5sum] = "519287f2ed8698b0018fbf07b35e0e4e"
+SRC_URI[sha256sum] = "d1ee47fd91ae7ce2bf99cf85ed9108ac48c3fb5f29b31c7fbe94fac45c6e4a0b"
 
 SRC_URI += "\
     file://0001-default.conf-Use-pulseaudio-as-default-output.patch \
@@ -30,7 +30,7 @@ RDEPENDS_${PN} += "\
     python-pykka \
     python-requests \
     python-setuptools \
-    python-tornado45 \
+    python-tornado \
     python-xml \
     "
 


### PR DESCRIPTION
Changed dependency from python-tornado45 to python-tornado from
meta-openembedded as this version supports python-tornado 5 and 6.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>