### PR TITLE
layer.conf: add thud to LAYERSERIES_COMPAT for smarcimx8m

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -31,5 +31,6 @@ BBFILES_DYNAMIC += " \
 "
 
 LAYERSERIES_COMPAT_pelux-layer = "sumo thud warrior"
+LAYERSERIES_COMPAT_smarcimx8m_append = " thud"
 
 HOSTTOOLS += "bc"


### PR DESCRIPTION
LAYERSERIES_COMPAT in meta-smarcimx8m is set to 'sumo', but the layer
itself builds with thud perfectly fine.

Append layer's compatibility until it is upgraded in the upstream layer.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>