### PR TITLE
/etc/defaults/neptune: Change XDG_RUNTIME_DIR

### DIFF
--- a/dynamic-layers/b2qt/recipes-qt/automotive/neptune3-ui/neptune
+++ b/dynamic-layers/b2qt/recipes-qt/automotive/neptune3-ui/neptune
@@ -2,7 +2,7 @@ HOME=/home/%u/
 LC_ALL=en_US
 DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/0/dbus_session_socket
 QT_IM_MODULE=qtvirtualkeyboard
-XDG_RUNTIME_DIR=/tmp
+XDG_RUNTIME_DIR=/run/user/0
 QTWEBENGINE_CHROMIUM_FLAGS="--no-sandbox --single-process"
 WAYLAND_DISPLAY="qtam-wayland-0"
 QT_QPA_EGLFS_HIDECURSOR=1


### PR DESCRIPTION
There is a change in Qt 5.14, where the XDG_RUNTIME_DIR cannot be
/tmp since the permission for that dir is not read-only for the
current user (i.e. root). The default value of XDG_RUNTIME_DIR as
defined in meta-boot2qt is /run/user/0 so let's use this also.

TODO: Consider to reuse the default Qt config as defined in the
boot2qt addons and only apply modifications applicable for PELUX.

Signed-off-by: Johan Ederonn <jederonn@luxoft.com>