### PR TITLE
pelux.conf: Temporarily disable DISTRO_FEATURE process-containment

### DIFF
--- a/conf/distro/pelux.conf
+++ b/conf/distro/pelux.conf
@@ -28,6 +28,22 @@ DISTRO_FEATURES_append = " \
     webengine\
 "
 
+# Temporarily disable process-containment due to some issues which
+# cannot be fixed right now:
+#  - (BLOCKER) Qt 5.14 AS candidate results in build error
+#    ERROR: Required build target 'neptune3-ui' has no buildable providers.
+#    Missing or unbuildable dependency chain was: [
+#      'neptune3-ui',
+#      'qtapplicationmanager-native',
+#      'qtapplicationmanager-native-softwarecontainer-native']
+#  - With Qt 5.13, Neptune3-UI cannot run applications in container
+#    (workaround is to not provide sc-config.yaml to neptune3-ui)
+#  - Sometimes at system shutdown, the softwarecontainer-agent does
+#    not stop within maximum timeout
+DISTRO_FEATURES_remove = " \
+    process-containment \
+"
+
 # Remove unused poky features
 DISTRO_FEATURES_remove = " \
     3g \


### PR DESCRIPTION
Due to some issues which cannot be fixed right now:
- (BLOCKER) Qt 5.14 AS candidate results in build error
  ERROR: Required build target 'neptune3-ui' has no buildable providers.
  Missing or unbuildable dependency chain was: [
    'neptune3-ui',
    'qtapplicationmanager-native',
    'qtapplicationmanager-native-softwarecontainer-native']
- With Qt 5.13, Neptune3-UI cannot run applications in container
  (workaround is to not provide sc-config.yaml to neptune3-ui)
- Sometimes at system shutdown, the softwarecontainer-agent does
  not stop within maximum timeout