### PR TITLE
qtivi-mopidy-plugin_git.bb: Add suffix _simulation to lib

### DIFF
--- a/classes/core-image-pelux-qtauto.bbclass
+++ b/classes/core-image-pelux-qtauto.bbclass
@@ -12,7 +12,6 @@ inherit core-image-pelux
 QTAUTO_COMPONENTS = " \
     qtapplicationmanager \
     qtivi \
-    qtivi-mopidy-plugin \
     qtvirtualkeyboard \
 "
 

--- a/dynamic-layers/b2qt/recipes-multimedia/qtivi-mopidy-plugin/qtivi-mopidy-plugin_git.bb
+++ b/dynamic-layers/b2qt/recipes-multimedia/qtivi-mopidy-plugin/qtivi-mopidy-plugin_git.bb
@@ -16,7 +16,7 @@ inherit qmake5
 
 do_install() {
     install -m 0755 -d ${D}${libdir}/plugins/qtivi/
-    install -m 0644 ${WORKDIR}/build/libmedia_mopidy.so ${D}${libdir}/plugins/qtivi/libzzmedia_mopidy_experimental.so
+    install -m 0644 ${WORKDIR}/build/libmedia_mopidy.so ${D}${libdir}/plugins/qtivi/libmedia_mopidy_experimental.so
 }
 
 FILES_${PN} += "${libdir}/plugins/qtivi/"


### PR DESCRIPTION
The intention has been that the QtIvi Media mopidy plugin shall
not be selected since it's still experimental and not complete.
The problem is that it is still selected due to incorrect naming.

The method QIviServiceManagerPrivate::isSimulation returns TRUE
if the QtIvi plugin library name contains _simulation.