### PR TITLE
mopidy: add python-futures to rdepends

### DIFF
--- a/recipes-multimedia/mopidy/mopidy_2.3.1.bb
+++ b/recipes-multimedia/mopidy/mopidy_2.3.1.bb
@@ -26,6 +26,7 @@ RDEPENDS_${PN} += "\
     gstreamer1.0-plugins-good \
     gstreamer1.0-python \
     python-argparse \
+    python-futures \
     python-pygobject \
     python-pykka \
     python-requests \


### PR DESCRIPTION
python-tornado that is a dependancy of mopidy requires python-futures package.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>