### PR TITLE
mopidy: add python-misc to rdepends

### DIFF
--- a/recipes-multimedia/mopidy/mopidy_2.3.1.bb
+++ b/recipes-multimedia/mopidy/mopidy_2.3.1.bb
@@ -27,6 +27,7 @@ RDEPENDS_${PN} += "\
     gstreamer1.0-python \
     python-argparse \
     python-futures \
+    python-misc \
     python-pygobject \
     python-pykka \
     python-requests \


### PR DESCRIPTION
python-tornado depends on ntpath module which was moved to python-misc
package on Yocto "Warrior".

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>