### PR TITLE
neptune3-ui: Move Environment setting for HOME

### DIFF
--- a/dynamic-layers/b2qt/recipes-qt/automotive/neptune3-ui/neptune
+++ b/dynamic-layers/b2qt/recipes-qt/automotive/neptune3-ui/neptune
@@ -1,4 +1,3 @@
-HOME=/home/%u/
 LC_ALL=en_US
 DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/0/dbus_session_socket
 QT_IM_MODULE=qtvirtualkeyboard

--- a/dynamic-layers/b2qt/recipes-qt/automotive/neptune3-ui/pelux.conf
+++ b/dynamic-layers/b2qt/recipes-qt/automotive/neptune3-ui/pelux.conf
@@ -4,3 +4,4 @@ ExecStart=/opt/neptune3/neptune3-ui -r --dbus session -c am-config-neptune.yaml 
 WorkingDirectory=/opt/neptune3
 EnvironmentFile=
 EnvironmentFile=/etc/default/neptune
+Environment=HOME=/home/%u/


### PR DESCRIPTION
Can not use %u in EnvironmentFile since it will not be converted
to current user.

Problem to fix: If you download apps in Neptune, these will be installed in /home/%u/.local/share and not in /home/root.
