### PR TITLE
gstreamer1.0: Re-enable wayland support

### DIFF
--- a/recipes-temporary-patches/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/recipes-temporary-patches/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -2,7 +2,3 @@
 # and uses qemu for this. For aarch64, these commands cause qemu to crash, so
 # we disable introspection.
 EXTRA_OECONF_aarch64 += "--disable-introspection"
-
-# Wayland support is broken, so remove this until it is fixed upstream. Fixes:
-# | make[3]: *** No rule to make target 'viewporter-protocol.c', needed by 'all'.  Stop.
-PACKAGECONFIG_remove_aarch64 = "wayland"


### PR DESCRIPTION
Wayland was temporarily removed a few years! ago due to a
compilation error for 64-bit arch. Should have been fixed now.

Signed-off-by: Johan Ederonn <jederonn@luxoft.com>