### PR TITLE
python3-watchdog_0.8.5: fix PYPI_SRC_URI

### DIFF
--- a/dynamic-layers/b2qt/recipes-devtools/python/python3-watchdog_0.8.5.bbappend
+++ b/dynamic-layers/b2qt/recipes-devtools/python/python3-watchdog_0.8.5.bbappend
@@ -1,0 +1,5 @@
+# The main recipe in meta-boot2qt points to a url for this package which is
+# obsolete. It has been fixed in warrior but not in QtAS_5.13.
+PYPI_SRC_URI = "http://152.3.102.14/pypi/packages/36/48/743fa68f043bf8cab48e1fa70503a49c18ade92c543f7517af2ab3fdfaff/watchdog3-0.8.5.tar.gz"
+
+


### PR DESCRIPTION
Python3-watchdog that is a dependency of qtivi was renamed in pypi
from watchdog3 to watchdog. This stops any of the automotive builds.

Fixes: AUTOSUITE-1504

Fixed in upstream thud branch but not for QtAS branch. Therefore,
this fix is cherry-picked here.